### PR TITLE
feat: per-ASN arm accuracy and selection probability in ISP panel

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -60,6 +60,15 @@ export interface DashboardArmEntry {
   armId: string;
   weight: number;
   blocked: boolean;
+  regionName?: string;
+  trackName?: string;
+  regionId?: number;
+  trackId?: number;
+  routeCount?: number;
+  selectionProbability?: number;
+  successCount?: number;
+  totalTests?: number;
+  successRate?: number;
 }
 
 export interface DashboardASN {

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -764,7 +764,23 @@ export function asnDisplayName(asn: string): string {
 
 // ── ISP Panel — shown when a country is selected ──
 
-function ISPPanel({
+function rateColor(rate: number, invert = false): string {
+  const r = invert ? 1 - rate : rate;
+  if (r > 0.8) return "#a0c8a0";
+  if (r > 0.5) return "#d8c090";
+  if (r > 0) return "#e0a080";
+  return "#667080";
+}
+
+function MiniBar({ value, color }: { value: number; color: string }) {
+  return (
+    <div style={{ flex: 1, height: "3px", background: "#ffffff08", borderRadius: "2px", overflow: "hidden" }}>
+      <div style={{ height: "100%", width: `${Math.min(1, value) * 100}%`, background: color, opacity: 0.5, borderRadius: "2px" }} />
+    </div>
+  );
+}
+
+const ISPPanel = memo(function ISPPanel({
   country,
   asns,
   loading,
@@ -873,24 +889,21 @@ function ISPPanel({
                     {asn.asn}
                   </span>
                 </div>
-                {/* Traffic bar */}
-                <div style={{ marginTop: "3px", height: "3px", background: "#ffffff08", borderRadius: "2px", overflow: "hidden" }}>
-                  <div style={{ height: "100%", width: `${pullBar * 100}%`, background: color, opacity: 0.5, borderRadius: "2px" }} />
+                <div style={{ marginTop: "3px" }}>
+                  <MiniBar value={pullBar} color={color} />
                 </div>
-                {/* Stats row */}
                 <div style={{ display: "flex", gap: "0.6rem", marginTop: "3px", fontSize: "0.48rem", color: "#667080" }}>
                   <span>{asn.numArms} arms</span>
-                  <span style={{ color: blockRate > 0.3 ? "#e0a080" : blockRate > 0.1 ? "#d8c090" : "#a0c8a0" }}>
+                  <span style={{ color: rateColor(blockRate, true) }}>
                     {asn.numBlocked} blocked
                   </span>
                   <span>{asn.totalPulls.toLocaleString()} pulls</span>
                 </div>
-                {/* Arm detail when selected */}
                 {isSelected && asn.topArms.length > 0 && (
                   <div style={{ marginTop: "6px", borderTop: `1px solid ${color}15`, paddingTop: "5px" }}>
-                    {asn.topArms.map((arm) => {
+                    {asn.topArms.slice(0, 20).map((arm) => {
                       const sr = arm.successRate ?? 0;
-                      const srColor = sr > 0.8 ? "#a0c8a0" : sr > 0.5 ? "#d8c090" : sr > 0 ? "#e0a080" : "#667080";
+                      const srClr = rateColor(sr);
                       const prob = arm.selectionProbability ?? 0;
                       return (
                         <div key={arm.armId} style={{ marginBottom: "5px", fontSize: "0.48rem" }}>
@@ -901,18 +914,14 @@ function ISPPanel({
                             </span>
                             {arm.blocked && <span style={{ color: "#e06060", fontSize: "0.42rem" }}>BLOCKED</span>}
                           </div>
-                          {/* Success rate bar */}
                           {arm.totalTests != null && arm.totalTests > 0 && (
                             <div style={{ display: "flex", alignItems: "center", gap: "4px", marginTop: "2px" }}>
-                              <div style={{ flex: 1, height: "3px", background: "#ffffff08", borderRadius: "2px", overflow: "hidden" }}>
-                                <div style={{ height: "100%", width: `${sr * 100}%`, background: srColor, borderRadius: "2px" }} />
-                              </div>
-                              <span style={{ color: srColor, minWidth: "28px", textAlign: "right" }}>
+                              <MiniBar value={sr} color={srClr} />
+                              <span style={{ color: srClr, minWidth: "28px", textAlign: "right" }}>
                                 {Math.round(sr * 100)}%
                               </span>
                             </div>
                           )}
-                          {/* Metrics row */}
                           <div style={{ display: "flex", gap: "0.5rem", marginTop: "2px", fontSize: "0.42rem", color: "#667080" }}>
                             {arm.totalTests != null && arm.totalTests > 0 && (
                               <span>{arm.successCount}/{arm.totalTests} tests</span>
@@ -939,7 +948,7 @@ function ISPPanel({
       )}
     </div>
   );
-}
+});
 
 // ── Main ──
 

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -765,17 +765,19 @@ export function asnDisplayName(asn: string): string {
 // ── ISP Panel — shown when a country is selected ──
 
 function rateColor(rate: number, invert = false): string {
-  const r = invert ? 1 - rate : rate;
+  const raw = invert ? 1 - rate : rate;
+  if (!Number.isFinite(raw)) return "#667080";
+  const r = Math.min(1, Math.max(0, raw));
   if (r > 0.8) return "#a0c8a0";
   if (r > 0.5) return "#d8c090";
-  if (r > 0) return "#e0a080";
-  return "#667080";
+  return "#e0a080";
 }
 
 function MiniBar({ value, color }: { value: number; color: string }) {
+  const clamped = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
   return (
     <div style={{ flex: 1, height: "3px", background: "#ffffff08", borderRadius: "2px", overflow: "hidden" }}>
-      <div style={{ height: "100%", width: `${Math.min(1, value) * 100}%`, background: color, opacity: 0.5, borderRadius: "2px" }} />
+      <div style={{ height: "100%", width: `${clamped * 100}%`, background: color, opacity: 0.5, borderRadius: "2px" }} />
     </div>
   );
 }
@@ -902,7 +904,8 @@ const ISPPanel = memo(function ISPPanel({
                 {isSelected && asn.topArms.length > 0 && (
                   <div style={{ marginTop: "6px", borderTop: `1px solid ${color}15`, paddingTop: "5px" }}>
                     {asn.topArms.slice(0, 20).map((arm) => {
-                      const sr = arm.successRate ?? 0;
+                      const hasTests = arm.totalTests != null && arm.totalTests > 0;
+                      const sr = arm.successRate ?? (hasTests && arm.successCount != null ? arm.successCount / arm.totalTests! : NaN);
                       const srClr = rateColor(sr);
                       const prob = arm.selectionProbability ?? 0;
                       return (
@@ -914,7 +917,7 @@ const ISPPanel = memo(function ISPPanel({
                             </span>
                             {arm.blocked && <span style={{ color: "#e06060", fontSize: "0.42rem" }}>BLOCKED</span>}
                           </div>
-                          {arm.totalTests != null && arm.totalTests > 0 && (
+                          {hasTests && Number.isFinite(sr) && (
                             <div style={{ display: "flex", alignItems: "center", gap: "4px", marginTop: "2px" }}>
                               <MiniBar value={sr} color={srClr} />
                               <span style={{ color: srClr, minWidth: "28px", textAlign: "right" }}>
@@ -923,7 +926,7 @@ const ISPPanel = memo(function ISPPanel({
                             </div>
                           )}
                           <div style={{ display: "flex", gap: "0.5rem", marginTop: "2px", fontSize: "0.42rem", color: "#667080" }}>
-                            {arm.totalTests != null && arm.totalTests > 0 && (
+                            {hasTests && arm.successCount != null && (
                               <span>{arm.successCount}/{arm.totalTests} tests</span>
                             )}
                             {prob > 0 && <span>P={Math.round(prob * 100)}%</span>}

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -789,7 +789,7 @@ function ISPPanel({
         bottom: "5.5rem",
         right: "0.75rem",
         zIndex: 20,
-        width: "220px",
+        width: "260px",
         background: "rgba(12, 14, 20, 0.92)",
         backdropFilter: "blur(12px)",
         border: `1px solid ${color}30`,
@@ -833,7 +833,7 @@ function ISPPanel({
       </div>
 
       {/* ISP list */}
-      <div style={{ maxHeight: "200px", overflowY: "auto", padding: "0.3rem 0" }}>
+      <div style={{ maxHeight: "320px", overflowY: "auto", padding: "0.3rem 0" }}>
         {loading ? (
           <div style={{ padding: "1rem", textAlign: "center", fontSize: "0.55rem", color: "#667080" }}>
             Loading ISPs...
@@ -885,6 +885,46 @@ function ISPPanel({
                   </span>
                   <span>{asn.totalPulls.toLocaleString()} pulls</span>
                 </div>
+                {/* Arm detail when selected */}
+                {isSelected && asn.topArms.length > 0 && (
+                  <div style={{ marginTop: "6px", borderTop: `1px solid ${color}15`, paddingTop: "5px" }}>
+                    {asn.topArms.map((arm) => {
+                      const sr = arm.successRate ?? 0;
+                      const srColor = sr > 0.8 ? "#a0c8a0" : sr > 0.5 ? "#d8c090" : sr > 0 ? "#e0a080" : "#667080";
+                      const prob = arm.selectionProbability ?? 0;
+                      return (
+                        <div key={arm.armId} style={{ marginBottom: "5px", fontSize: "0.48rem" }}>
+                          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                            <span style={{ color: arm.blocked ? "#e0a080" : "#c8ccd4", fontWeight: 500 }}>
+                              {arm.trackName || arm.armId}
+                              {arm.regionName ? ` · ${arm.regionName}` : ""}
+                            </span>
+                            {arm.blocked && <span style={{ color: "#e06060", fontSize: "0.42rem" }}>BLOCKED</span>}
+                          </div>
+                          {/* Success rate bar */}
+                          {arm.totalTests != null && arm.totalTests > 0 && (
+                            <div style={{ display: "flex", alignItems: "center", gap: "4px", marginTop: "2px" }}>
+                              <div style={{ flex: 1, height: "3px", background: "#ffffff08", borderRadius: "2px", overflow: "hidden" }}>
+                                <div style={{ height: "100%", width: `${sr * 100}%`, background: srColor, borderRadius: "2px" }} />
+                              </div>
+                              <span style={{ color: srColor, minWidth: "28px", textAlign: "right" }}>
+                                {Math.round(sr * 100)}%
+                              </span>
+                            </div>
+                          )}
+                          {/* Metrics row */}
+                          <div style={{ display: "flex", gap: "0.5rem", marginTop: "2px", fontSize: "0.42rem", color: "#667080" }}>
+                            {arm.totalTests != null && arm.totalTests > 0 && (
+                              <span>{arm.successCount}/{arm.totalTests} tests</span>
+                            )}
+                            {prob > 0 && <span>P={Math.round(prob * 100)}%</span>}
+                            {arm.routeCount != null && arm.routeCount > 0 && <span>{arm.routeCount} routes</span>}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             );
           })


### PR DESCRIPTION
## Summary
- Expand `DashboardArmEntry` type with fields from enriched backend: `regionName`, `trackName`, `routeCount`, `selectionProbability`, `successCount`, `totalTests`, `successRate`
- When an ASN is selected in the ISP panel, show expandable arm detail: track + region, success rate bar, test counts, selection probability, route count, blocked indicator
- Extract `MiniBar` component and `rateColor()` helper to deduplicate progress bar and color-grading patterns
- Wrap `ISPPanel` in `memo()` to prevent re-renders from parent pulse ticks
- Cap `topArms` rendering to 20 items

## Test plan
- [ ] Click a country, select an ISP — arm detail expands with per-arm stats
- [ ] Success rate bars colored correctly (green >80%, amber >50%, red <50%)
- [ ] Selection probability shown as P=X%
- [ ] Blocked arms show red BLOCKED indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)