### PR TITLE
feat: VPS Fleet overview tab

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -170,6 +170,42 @@ export function fetchTrafficFlows(): Promise<DashboardTrafficFlowsResponse> {
   return apiFetch("/traffic-flows");
 }
 
+export interface DashboardVPSRoute {
+  id: string;
+  address?: string;
+  port?: number;
+  created: string;
+  deprecated?: string;
+  status: string;
+  vpsProvider: string;
+  vpsRegion: string;
+  vpsInstanceId?: string;
+  assignmentCount: number;
+  peakAssignmentCount: number;
+  trackName: string;
+  protocolName: string;
+  locationName?: string;
+  providerName: string;
+  regionName: string;
+  city?: string;
+  countryCode?: string;
+}
+
+export interface DashboardVPSSummary {
+  total: number;
+  byStatus: Record<string, number>;
+  byProvider: Record<string, number>;
+}
+
+export interface DashboardVPSRoutesResponse {
+  routes: DashboardVPSRoute[];
+  summary: DashboardVPSSummary;
+}
+
+export function fetchVPSRoutes(): Promise<DashboardVPSRoutesResponse> {
+  return apiFetch("/vps-routes");
+}
+
 export function getStreamURL(): string {
   const url = new URL(`${API_URL}/v1/dashboard/stream`);
   if (authToken) url.searchParams.set("token", authToken);

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,11 +3,13 @@ import { useAuth } from "../hooks/useAuth";
 import { useLiveData } from "../hooks/useLiveData";
 import { useProxy } from "../hooks/useProxy";
 import { useGeoLookup } from "../hooks/useGeoLookup";
+import { useVPSData } from "../hooks/useVPSData";
 import WorldMap, { type MapSelection } from "./WorldMap";
 import StatsRow from "./StatsRow";
 import ImpactCard from "./ImpactCard";
 import ProtocolFeed from "./ProtocolFeed";
 import ProxyWidget from "./ProxyWidget";
+import VPSOverview from "./VPSOverview";
 import type { GlobalStats } from "../data/mock";
 
 function LanternLogo() {
@@ -29,6 +31,8 @@ function LanternLogo() {
 export default function Dashboard() {
   const { isAuthenticated, user, logout } = useAuth();
   const { globalStats, dataCenters, activityEvents, trafficFlows, volunteerStats, isLive, blockedRoutes, demoMode, toggleDemoMode } = useLiveData();
+  const [activeTab, setActiveTab] = useState<'map' | 'vps'>('map');
+  const vpsData = useVPSData(activeTab === 'vps');
   const proxy = useProxy();
   const [myProxyView, setMyProxyView] = useState(false);
   const connectionAddrs = useMemo(
@@ -100,7 +104,30 @@ export default function Dashboard() {
             <div className="header-subtitle">Impact Dashboard</div>
           </div>
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+        <div style={{ display: "flex", gap: "0.25rem", marginLeft: "1.5rem" }}>
+          {(["map", "vps"] as const).map((tab) => (
+            <div
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.55rem",
+                padding: "0.15rem 0.55rem",
+                borderRadius: "var(--radius-sm)",
+                background: activeTab === tab ? "var(--accent-primary-dim)" : "#ffffff08",
+                color: activeTab === tab ? "var(--accent-primary)" : "var(--text-muted)",
+                border: `1px solid ${activeTab === tab ? "#00e5c830" : "#ffffff10"}`,
+                cursor: "pointer",
+                userSelect: "none" as const,
+                textTransform: "uppercase" as const,
+                letterSpacing: "0.05em",
+              }}
+            >
+              {tab === "map" ? "Map" : "VPS Fleet"}
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem", marginLeft: "auto" }}>
           <div
             onClick={toggleDemoMode}
             style={{
@@ -168,6 +195,14 @@ export default function Dashboard() {
       </header>
 
       <div className="main-layout">
+        {activeTab === "vps" ? (
+          <VPSOverview
+            routes={vpsData.routes}
+            summary={vpsData.summary}
+            isLoading={vpsData.isLoading}
+            error={vpsData.error}
+          />
+        ) : (
         <div className="map-section">
           <div className="map-header">
             <h2>Global Network</h2>
@@ -258,6 +293,7 @@ export default function Dashboard() {
           </div>
           <StatsRow stats={displayStats} filterLabel={filterLabel} proxyLive={proxy.isRunning ? proxy.liveData : null} />
         </div>
+        )}
 
         <div className="right-panel">
           <ProxyWidget {...proxy} />

--- a/src/components/VPSOverview.tsx
+++ b/src/components/VPSOverview.tsx
@@ -1,0 +1,367 @@
+import { useState, useMemo, useEffect, memo, type CSSProperties } from "react";
+import type { DashboardVPSRoute, DashboardVPSSummary } from "../api/client";
+
+interface VPSOverviewProps {
+  routes: DashboardVPSRoute[];
+  summary: DashboardVPSSummary | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  running: "#a0c8a0",
+  configuring: "#f0a030",
+  provisioning: "#f0a030",
+  pending: "#667080",
+};
+
+function statusColor(route: DashboardVPSRoute): string {
+  if (route.deprecated) return "#e06060";
+  return STATUS_COLORS[route.status] || "#667080";
+}
+
+function formatUptime(createdISO: string): string {
+  const elapsed = Date.now() - Date.parse(createdISO);
+  if (elapsed < 0) return "0m";
+  const totalMinutes = Math.floor(elapsed / 60_000);
+  const totalHours = Math.floor(totalMinutes / 60);
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  const minutes = totalMinutes % 60;
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+interface RegionGroup {
+  regionName: string;
+  city?: string;
+  tracks: TrackGroup[];
+  totalRoutes: number;
+}
+
+interface TrackGroup {
+  trackName: string;
+  protocolName: string;
+  routes: DashboardVPSRoute[];
+}
+
+const card: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  padding: "1rem 1.1rem",
+  minWidth: 0,
+  flex: "1 1 0",
+};
+
+const cardLabel: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.6rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "#8890a0",
+  marginBottom: "0.3rem",
+};
+
+const cardValue: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "1.6rem",
+  fontWeight: 600,
+  lineHeight: 1.15,
+};
+
+const chipStyle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.5rem",
+  padding: "0.1rem 0.4rem",
+  borderRadius: "3px",
+  background: "#ffffff08",
+  color: "#8890a0",
+  whiteSpace: "nowrap",
+};
+
+const tableContainer: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  overflow: "auto",
+  maxHeight: "calc(100vh - 280px)",
+};
+
+const regionHeaderStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.6rem",
+  padding: "0.65rem 1rem",
+  cursor: "pointer",
+  userSelect: "none",
+  borderBottom: "1px solid #ffffff06",
+  background: "rgba(255,255,255,0.015)",
+  transition: "background 0.15s",
+};
+
+const trackHeaderStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  padding: "0.4rem 1rem 0.4rem 2.2rem",
+  borderBottom: "1px solid #ffffff04",
+  background: "rgba(255,255,255,0.008)",
+};
+
+const rowStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "20px 1fr 0.7fr 0.6fr 0.5fr 0.6fr 0.5fr",
+  alignItems: "center",
+  gap: "0.5rem",
+  padding: "0.4rem 1rem 0.4rem 3rem",
+  borderBottom: "1px solid #ffffff04",
+  fontSize: "0.65rem",
+  fontFamily: "var(--font-mono)",
+  color: "#c0c8d4",
+  minHeight: "2rem",
+};
+
+const badgeBase: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.48rem",
+  padding: "0.1rem 0.35rem",
+  borderRadius: "3px",
+  textTransform: "uppercase",
+  letterSpacing: "0.03em",
+  whiteSpace: "nowrap",
+};
+
+function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
+  const [collapsedRegions, setCollapsedRegions] = useState<Set<string>>(new Set());
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const toggleRegion = (regionName: string) => {
+    setCollapsedRegions((prev) => {
+      const next = new Set(prev);
+      if (next.has(regionName)) next.delete(regionName);
+      else next.add(regionName);
+      return next;
+    });
+  };
+
+  const regionGroups: RegionGroup[] = useMemo(() => {
+    const regionMap = new Map<string, { city?: string; trackMap: Map<string, { protocolName: string; routes: DashboardVPSRoute[] }> }>();
+
+    for (const route of routes) {
+      const rKey = route.regionName || "Unknown";
+      if (!regionMap.has(rKey)) {
+        regionMap.set(rKey, { city: route.city, trackMap: new Map() });
+      }
+      const region = regionMap.get(rKey)!;
+      const tKey = route.trackName || "default";
+      if (!region.trackMap.has(tKey)) {
+        region.trackMap.set(tKey, { protocolName: route.protocolName, routes: [] });
+      }
+      region.trackMap.get(tKey)!.routes.push(route);
+    }
+
+    return Array.from(regionMap.entries())
+      .map(([regionName, { city, trackMap }]) => {
+        const tracks: TrackGroup[] = Array.from(trackMap.entries()).map(([trackName, { protocolName, routes: tRoutes }]) => ({
+          trackName,
+          protocolName,
+          routes: tRoutes.sort((a, b) => (a.deprecated ? 1 : 0) - (b.deprecated ? 1 : 0) || a.status.localeCompare(b.status)),
+        }));
+        const totalRoutes = tracks.reduce((s, t) => s + t.routes.length, 0);
+        return { regionName, city, tracks, totalRoutes };
+      })
+      .sort((a, b) => b.totalRoutes - a.totalRoutes);
+  }, [routes]);
+
+  const deprecatedCount = useMemo(() => routes.filter((r) => r.deprecated).length, [routes]);
+  const provisioningCount = useMemo(() => {
+    if (summary?.byStatus) {
+      return (summary.byStatus["pending"] || 0) + (summary.byStatus["provisioning"] || 0) + (summary.byStatus["configuring"] || 0);
+    }
+    return routes.filter((r) => ["pending", "provisioning", "configuring"].includes(r.status)).length;
+  }, [summary, routes]);
+  const runningCount = summary?.byStatus?.["running"] ?? routes.filter((r) => r.status === "running" && !r.deprecated).length;
+  const totalCount = summary?.total ?? routes.length;
+
+  if (isLoading) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: 300, color: "#667080", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
+        Loading VPS data...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: 300, color: "#e06060", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
+        {error}
+      </div>
+    );
+  }
+
+  if (routes.length === 0) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: 300, color: "#667080", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
+        No active VPS routes
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+      {/* Summary Cards */}
+      <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
+        <div style={card}>
+          <div style={cardLabel}>Total VPS</div>
+          <div style={{ ...cardValue, color: "#00e5c8" }}>{totalCount}</div>
+          {summary?.byProvider && (
+            <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap", marginTop: "0.45rem" }}>
+              {Object.entries(summary.byProvider).map(([provider, count]) => (
+                <span key={provider} style={chipStyle}>
+                  {provider} {count}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div style={card}>
+          <div style={cardLabel}>Running</div>
+          <div style={{ ...cardValue, color: "#a0c8a0" }}>{runningCount}</div>
+        </div>
+
+        <div style={card}>
+          <div style={cardLabel}>Provisioning</div>
+          <div style={{ ...cardValue, color: "#f0a030" }}>{provisioningCount}</div>
+        </div>
+
+        <div style={card}>
+          <div style={cardLabel}>Deprecated</div>
+          <div style={{ ...cardValue, color: "#e06060" }}>{deprecatedCount}</div>
+        </div>
+      </div>
+
+      {/* Grouped Table */}
+      <div style={tableContainer}>
+        {/* Column headers */}
+        <div style={{ ...rowStyle, padding: "0.5rem 1rem 0.5rem 3rem", color: "#667080", fontSize: "0.5rem", textTransform: "uppercase", letterSpacing: "0.06em", fontFamily: "var(--font-sans)", borderBottom: "1px solid #ffffff08", position: "sticky", top: 0, background: "var(--bg-card)", zIndex: 2 }}>
+          <span />
+          <span>Address</span>
+          <span>Provider</span>
+          <span>VPS Region</span>
+          <span>Uptime</span>
+          <span>Assignments</span>
+          <span>Status</span>
+        </div>
+
+        {regionGroups.map((region) => {
+          const collapsed = collapsedRegions.has(region.regionName);
+          return (
+            <div key={region.regionName}>
+              {/* Region header */}
+              <div
+                style={regionHeaderStyle}
+                onClick={() => toggleRegion(region.regionName)}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.03)"; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.015)"; }}
+              >
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.55rem", color: "#667080", width: "1rem", textAlign: "center", transition: "transform 0.15s", transform: collapsed ? "rotate(-90deg)" : "rotate(0deg)" }}>
+                  &#9662;
+                </span>
+                <span style={{ fontFamily: "var(--font-sans)", fontSize: "0.75rem", fontWeight: 600, color: "#d0d8e4" }}>
+                  {region.regionName}
+                </span>
+                {region.city && (
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.55rem", color: "#667080" }}>
+                    {region.city}
+                  </span>
+                )}
+                <span style={{ marginLeft: "auto", ...chipStyle }}>
+                  {region.totalRoutes} route{region.totalRoutes !== 1 ? "s" : ""}
+                </span>
+              </div>
+
+              {!collapsed && region.tracks.map((track) => (
+                <div key={`${region.regionName}-${track.trackName}`}>
+                  {/* Track sub-header */}
+                  <div style={trackHeaderStyle}>
+                    <span style={{ fontFamily: "var(--font-sans)", fontSize: "0.62rem", fontWeight: 500, color: "#a0a8b8" }}>
+                      {track.trackName}
+                    </span>
+                    <span style={{ ...badgeBase, background: "#ffffff06", color: "#667080" }}>
+                      {track.protocolName}
+                    </span>
+                  </div>
+
+                  {/* Route rows */}
+                  {track.routes.map((route) => {
+                    const sc = statusColor(route);
+                    const addr = route.address && route.port ? `${route.address}:${route.port}` : route.address || "--";
+                    const isDeprecated = !!route.deprecated;
+
+                    return (
+                      <div key={route.id} style={{ ...rowStyle, opacity: isDeprecated ? 0.5 : 1 }}>
+                        {/* Status dot */}
+                        <span style={{ width: 7, height: 7, borderRadius: "50%", background: sc, boxShadow: `0 0 5px ${sc}60`, display: "inline-block", flexShrink: 0 }} />
+
+                        {/* IP:port */}
+                        <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.6rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                          {addr}
+                        </span>
+
+                        {/* Provider badge */}
+                        <span>
+                          <span style={{ ...badgeBase, background: "#ffffff08", color: "#a0a8b8" }}>
+                            {route.providerName}
+                          </span>
+                        </span>
+
+                        {/* VPS region */}
+                        <span style={{ fontSize: "0.58rem", color: "#8890a0" }}>
+                          {route.vpsRegion}
+                        </span>
+
+                        {/* Uptime */}
+                        <span style={{ fontSize: "0.58rem", color: "#8890a0" }}>
+                          {formatUptime(route.created)}
+                        </span>
+
+                        {/* Assignments */}
+                        <span style={{ fontSize: "0.58rem" }}>
+                          <span style={{ color: "#c0c8d4" }}>{route.assignmentCount}</span>
+                          <span style={{ color: "#667080" }}> / {route.peakAssignmentCount}</span>
+                        </span>
+
+                        {/* Status / Deprecated badge */}
+                        <span>
+                          {isDeprecated ? (
+                            <span style={{ ...badgeBase, background: "#e0606018", color: "#e06060", border: "1px solid #e0606030" }}>
+                              deprecated
+                            </span>
+                          ) : (
+                            <span style={{ ...badgeBase, background: `${sc}18`, color: sc, border: `1px solid ${sc}30` }}>
+                              {route.status}
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default memo(VPSOverview);

--- a/src/hooks/useVPSData.ts
+++ b/src/hooks/useVPSData.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+import { fetchVPSRoutes, type DashboardVPSRoute, type DashboardVPSSummary } from "../api/client";
+import { useAuth } from "./useAuth";
+
+export function useVPSData(enabled: boolean) {
+  const { isAuthenticated } = useAuth();
+  const [routes, setRoutes] = useState<DashboardVPSRoute[]>([]);
+  const [summary, setSummary] = useState<DashboardVPSSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !isAuthenticated) return;
+    let cancelled = false;
+
+    const refresh = async () => {
+      setIsLoading(true);
+      try {
+        const data = await fetchVPSRoutes();
+        if (!cancelled) {
+          setRoutes(data.routes);
+          setSummary(data.summary);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load VPS data");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    refresh();
+    const interval = setInterval(refresh, 60000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [enabled, isAuthenticated]);
+
+  return { routes, summary, isLoading, error };
+}


### PR DESCRIPTION
## Summary
Add a second tab to the dashboard showing all deployed VPS instances.

### Tab Navigation
- Two pill-style tabs in the header: **Map** and **VPS Fleet**
- Switching tabs preserves map view state

### VPS Overview
- **Summary cards**: Total VPS, Running, Provisioning (pending+provisioning+configuring), Deprecated (24h)
- **Provider chips**: Breakdown by cloud provider under total count
- **Grouped table**: Routes organized by region → track, collapsible sections
- **Per route**: Status dot, IP:port, provider badge, VPS region, live uptime, assignment count/peak, deprecated badge

### Architecture
- New `useVPSData` hook — only fetches when VPS tab is active, polls every 60s
- New `VPSOverview` component — self-contained with memo wrapper
- Types + `fetchVPSRoutes()` in client.ts
- Requires backend `GET /v1/dashboard/vps-routes` (lantern-cloud PR #2412)

## Test plan
- [ ] Switch to VPS Fleet tab — summary cards populate
- [ ] Routes grouped by region/track with correct metadata
- [ ] Uptime values update periodically
- [ ] Status dots colored correctly (running=green, provisioning=amber, pending=gray)
- [ ] Deprecated routes show red badge
- [ ] Switching back to Map tab preserves map state
- [ ] VPS data only fetches when tab is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)