### PR TITLE
feat: Bandit Arms tab + ASN name database + metric explanations

### DIFF
--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -25,8 +25,33 @@ const COUNTRY_NAMES: Record<string, string> = {
   TZ: "Tanzania",
 };
 
+const COUNTRY_NAMES_EXTRA: Record<string, string> = {
+  LK: "Sri Lanka", MM: "Myanmar", BD: "Bangladesh", NP: "Nepal",
+  KH: "Cambodia", LA: "Laos", TJ: "Tajikistan", KG: "Kyrgyzstan",
+  AZ: "Azerbaijan", GE: "Georgia", AM: "Armenia", SD: "Sudan",
+  SS: "South Sudan", ER: "Eritrea", DJ: "Djibouti", SO: "Somalia",
+  YE: "Yemen", SY: "Syria", LY: "Libya", TD: "Chad", CM: "Cameroon",
+  CD: "DR Congo", CG: "Congo", ZW: "Zimbabwe", MZ: "Mozambique",
+  HN: "Honduras", NI: "Nicaragua", HT: "Haiti", BO: "Bolivia",
+  EC: "Ecuador", PE: "Peru", CO: "Colombia", CL: "Chile", AR: "Argentina",
+  UY: "Uruguay", PY: "Paraguay", GH: "Ghana", CI: "Ivory Coast",
+  SN: "Senegal", ML: "Mali", BF: "Burkina Faso", NE: "Niger",
+  MG: "Madagascar", RW: "Rwanda", UG: "Uganda", AO: "Angola",
+  RS: "Serbia", HR: "Croatia", BA: "Bosnia", ME: "Montenegro",
+  MK: "North Macedonia", AL: "Albania", XK: "Kosovo", MD: "Moldova",
+  LT: "Lithuania", LV: "Latvia", EE: "Estonia", BG: "Bulgaria",
+  HU: "Hungary", CZ: "Czechia", SK: "Slovakia", SI: "Slovenia",
+  AT: "Austria", BE: "Belgium", DK: "Denmark", FI: "Finland",
+  NO: "Norway", IE: "Ireland", PT: "Portugal", ES: "Spain", IT: "Italy",
+  GR: "Greece", CY: "Cyprus", MT: "Malta", IS: "Iceland", LU: "Luxembourg",
+  TW: "Taiwan", HK: "Hong Kong", MO: "Macau", MN: "Mongolia",
+  NZ: "New Zealand", FJ: "Fiji", PG: "Papua New Guinea",
+  IL: "Israel", JO: "Jordan", LB: "Lebanon", KW: "Kuwait",
+  BH: "Bahrain", OM: "Oman", QA: "Qatar", PS: "Palestine",
+};
+
 function countryName(code: string): string {
-  return COUNTRY_NAMES[code] ?? code;
+  return COUNTRY_NAMES[code] ?? COUNTRY_NAMES_EXTRA[code] ?? code;
 }
 
 const ASN_NAMES: Record<string, string> = {
@@ -70,7 +95,10 @@ const ASN_NAMES: Record<string, string> = {
 };
 
 function asnDisplayName(asn: string): string {
-  return ASN_NAMES[asn] ?? asn;
+  if (ASN_NAMES[asn]) return ASN_NAMES[asn];
+  // Format unknown ASNs more readably: "AS44244" → "ASN 44244"
+  const num = asn.replace(/^AS/i, "");
+  return `ASN ${num}`;
 }
 
 function blockRateColor(rate: number): string {

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -113,9 +113,11 @@ const ASN_NAMES: Record<string, string> = {
 
 function asnDisplayName(asn: string, db: Record<string, string> | null): string {
   if (ASN_NAMES[asn]) return ASN_NAMES[asn];
-  if (db?.[asn]) return db[asn];
+  if (db && db[asn]) return db[asn];
+  // Also try without "AS" prefix in case the DB keys differ
   const num = asn.replace(/^AS/i, "");
-  return `ASN ${num}`;
+  if (db && db[num]) return db[num];
+  return db ? `ASN ${num}` : `${asn} (loading...)`;
 }
 
 function blockRateColor(rate: number): string {
@@ -162,6 +164,14 @@ const cardValue: CSSProperties = {
   fontSize: "1.6rem",
   fontWeight: 600,
   lineHeight: 1.15,
+};
+
+const cardHint: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.6rem",
+  color: "#667080",
+  marginTop: "0.25rem",
+  lineHeight: 1.3,
 };
 
 const countryHeaderStyle: CSSProperties = {
@@ -393,22 +403,26 @@ function BanditArmsOverview({ countries }: BanditArmsOverviewProps) {
         <div style={card}>
           <div style={cardLabel}>Countries</div>
           <div style={{ ...cardValue, color: "#00e5c8" }}>{countries.length}</div>
+          <div style={cardHint}>with active bandit routing</div>
         </div>
         <div style={card}>
           <div style={cardLabel}>Total ASNs</div>
           <div style={{ ...cardValue, color: "#c0c8d4" }}>{totalASNs}</div>
+          <div style={cardHint}>ISPs / network operators being served</div>
         </div>
         <div style={card}>
           <div style={cardLabel}>Avg Block Rate</div>
           <div style={{ ...cardValue, color: blockRateColor(weightedBlockRate) }}>
             {(weightedBlockRate * 100).toFixed(1)}%
           </div>
+          <div style={cardHint}>fraction of arms blocked by censors</div>
         </div>
         <div style={card}>
           <div style={cardLabel}>Avg Entropy</div>
           <div style={{ ...cardValue, color: "#a0b0c8" }}>
             {weightedEntropy.toFixed(3)}
           </div>
+          <div style={cardHint}>weight distribution spread — higher = more exploration, lower = converged on best arms</div>
         </div>
       </div>
 

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -342,7 +342,14 @@ function BanditArmsOverview({ countries }: BanditArmsOverviewProps) {
     [countries],
   );
 
-  const totalASNs = useMemo(() => countries.reduce((s, c) => s + c.asnCount, 0), [countries]);
+  const totalASNs = useMemo(() => {
+    let total = 0;
+    for (const c of countries) {
+      const cached = asnCache.get(c.country);
+      total += cached ? cached.length : c.asnCount;
+    }
+    return total;
+  }, [countries, asnCache]);
 
   const weightedBlockRate = useMemo(() => {
     const totalWeight = countries.reduce((s, c) => s + c.asnCount, 0);

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -10,17 +10,63 @@ interface BanditArmsOverviewProps {
   countries: DashboardCountry[];
 }
 
+const COUNTRY_NAMES: Record<string, string> = {
+  IR: "Iran", CN: "China", RU: "Russia", MM: "Myanmar", BY: "Belarus",
+  TM: "Turkmenistan", VN: "Vietnam", CU: "Cuba", SA: "Saudi Arabia",
+  PK: "Pakistan", UZ: "Uzbekistan", TH: "Thailand", AE: "UAE",
+  IN: "India", BD: "Bangladesh", EG: "Egypt", TR: "Turkey",
+  VE: "Venezuela", KZ: "Kazakhstan", US: "United States", GB: "United Kingdom",
+  FR: "France", DE: "Germany", JP: "Japan", KR: "South Korea",
+  AU: "Australia", CA: "Canada", SE: "Sweden", CH: "Switzerland",
+  NL: "Netherlands", SG: "Singapore", BR: "Brazil", MX: "Mexico",
+  ID: "Indonesia", NG: "Nigeria", KE: "Kenya", ZA: "South Africa",
+  UA: "Ukraine", PL: "Poland", RO: "Romania", IQ: "Iraq",
+  AF: "Afghanistan", MY: "Malaysia", PH: "Philippines", ET: "Ethiopia",
+  TZ: "Tanzania",
+};
+
+function countryName(code: string): string {
+  return COUNTRY_NAMES[code] ?? code;
+}
+
 const ASN_NAMES: Record<string, string> = {
-  AS44244: "Irancell",
-  AS197207: "MCI",
-  AS58224: "TCI",
-  AS12880: "Afranet",
-  AS4134: "China Telecom",
-  AS4837: "China Unicom",
-  AS9808: "China Mobile",
-  AS12389: "Rostelecom",
-  AS25513: "PJSC MTS",
-  AS8359: "MTS OJSC",
+  // Iran
+  AS44244: "Irancell", AS197207: "MCI", AS58224: "TCI", AS12880: "Afranet",
+  AS48434: "MCCI", AS49100: "Pars Online", AS56402: "Pardis",
+  AS43754: "Asiatech", AS25184: "Afranet ADSL",
+  // China
+  AS4134: "China Telecom", AS4837: "China Unicom", AS9808: "China Mobile",
+  AS56040: "China Mobile GD", AS56046: "China Mobile ZJ",
+  AS17621: "China Unicom Shanghai", AS4812: "China Telecom Shanghai",
+  AS9929: "China Unicom Backbone", AS23724: "China Unicom IDC",
+  // Russia
+  AS12389: "Rostelecom", AS25513: "MTS", AS8359: "MTS OJSC",
+  AS31133: "MegaFon", AS3216: "Vimpelcom", AS20485: "Transtelecom",
+  // Myanmar
+  AS136255: "MPT", AS133385: "Ooredoo", AS136442: "Telenor",
+  // Belarus
+  AS6697: "Beltelecom", AS25106: "MTS Belarus",
+  // Turkmenistan
+  AS51495: "Turkmentelecom",
+  // Vietnam
+  AS45899: "VNPT", AS7552: "Viettel", AS18403: "FPT Telecom",
+  // Cuba
+  AS27725: "ETECSA",
+  // Saudi Arabia
+  AS25019: "STC", AS35753: "Mobily", AS39386: "Zain KSA",
+  // Pakistan
+  AS9541: "Cybernet", AS45773: "PTCL", AS9557: "Nayatel",
+  AS59257: "Zong", AS56167: "Telenor Pakistan",
+  // UAE
+  AS5384: "Etisalat", AS15802: "du",
+  // Turkey
+  AS9121: "Turk Telekom", AS16135: "Turkcell", AS34984: "Superonline",
+  // Other
+  AS7018: "AT&T", AS7922: "Comcast", AS209: "CenturyLink",
+  AS3356: "Lumen", AS15169: "Google", AS13335: "Cloudflare",
+  AS16509: "Amazon", AS8075: "Microsoft", AS32934: "Facebook",
+  AS3320: "Deutsche Telekom", AS5511: "Orange", AS6830: "Liberty Global",
+  AS2856: "BT", AS6461: "Zayo", AS174: "Cogent",
 };
 
 function asnDisplayName(asn: string): string {
@@ -59,7 +105,7 @@ const card: CSSProperties = {
 
 const cardLabel: CSSProperties = {
   fontFamily: "var(--font-sans)",
-  fontSize: "0.6rem",
+  fontSize: "0.7rem",
   textTransform: "uppercase",
   letterSpacing: "0.06em",
   color: "#8890a0",
@@ -88,33 +134,33 @@ const countryHeaderStyle: CSSProperties = {
 const ispRowStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
-  gap: "0.5rem",
-  padding: "0.45rem 0.75rem 0.45rem 1.5rem",
+  gap: "0.6rem",
+  padding: "0.55rem 0.75rem 0.55rem 1.5rem",
   cursor: "pointer",
   userSelect: "none",
   borderBottom: "1px solid #ffffff04",
   background: "rgba(255,255,255,0.008)",
   transition: "background 0.15s",
   fontFamily: "var(--font-mono)",
-  fontSize: "0.65rem",
+  fontSize: "0.8rem",
   color: "#c0c8d4",
 };
 
 const armRowStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
-  gap: "0.5rem",
-  padding: "0.35rem 0.75rem 0.35rem 2.5rem",
+  gap: "0.6rem",
+  padding: "0.45rem 0.75rem 0.45rem 2.5rem",
   borderBottom: "1px solid #ffffff03",
   fontFamily: "var(--font-mono)",
-  fontSize: "0.6rem",
+  fontSize: "0.75rem",
   color: "#a0a8b8",
 };
 
 const chipStyle: CSSProperties = {
   fontFamily: "var(--font-mono)",
-  fontSize: "0.5rem",
-  padding: "0.1rem 0.4rem",
+  fontSize: "0.6rem",
+  padding: "0.15rem 0.45rem",
   borderRadius: "3px",
   background: "#ffffff08",
   color: "#8890a0",
@@ -206,9 +252,7 @@ function ISPSection({ asn, country, expandedASNs, toggleASN }: { asn: DashboardA
       >
         <span style={chevronStyle(expanded)}>&#9662;</span>
         <span style={{ fontWeight: 600, color: "#c0c8d4" }}>{name}</span>
-        {name !== asn.asn && (
-          <span style={{ fontSize: "0.5rem", color: "#667080" }}>{asn.asn}</span>
-        )}
+        <span style={{ fontSize: "0.65rem", color: "#667080" }}>{name !== asn.asn ? asn.asn : ""}</span>
         <span style={{ marginLeft: "auto", display: "flex", gap: "0.5rem", alignItems: "center" }}>
           <span style={chipStyle}>{asn.numArms} arms</span>
           <span style={{ ...chipStyle, color: blockedColor }}>{asn.numBlocked} blocked</span>
@@ -340,14 +384,14 @@ function BanditArmsOverview({ countries }: BanditArmsOverviewProps) {
                 onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.015)"; }}
               >
                 <span style={chevronStyle(expanded)}>&#9662;</span>
-                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.75rem", fontWeight: 700, color: "#00e5c8" }}>
-                  {c.country}
+                <span style={{ fontFamily: "var(--font-sans)", fontSize: "0.85rem", fontWeight: 700, color: "#00e5c8" }}>
+                  {countryName(c.country)}
                 </span>
                 <span style={chipStyle}>{c.asnCount} ASN{c.asnCount !== 1 ? "s" : ""}</span>
 
                 <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px" }}>
                   <MiniBar value={c.avgBlockRate} color={brColor} />
-                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.5rem", color: brColor, minWidth: "30px", textAlign: "right" }}>
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: brColor, minWidth: "30px", textAlign: "right" }}>
                     {(c.avgBlockRate * 100).toFixed(1)}%
                   </span>
                 </div>

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -112,11 +112,16 @@ const ASN_NAMES: Record<string, string> = {
 };
 
 function asnDisplayName(asn: string, db: Record<string, string> | null): string {
+  // The inline map uses "AS44244" keys
   if (ASN_NAMES[asn]) return ASN_NAMES[asn];
-  if (db && db[asn]) return db[asn];
-  // Also try without "AS" prefix in case the DB keys differ
+  const withPrefix = asn.startsWith("AS") ? asn : `AS${asn}`;
+  if (ASN_NAMES[withPrefix]) return ASN_NAMES[withPrefix];
+  // The JSON DB uses "AS209" keys, but API may return just "209"
+  if (db) {
+    if (db[asn]) return db[asn];
+    if (db[withPrefix]) return db[withPrefix];
+  }
   const num = asn.replace(/^AS/i, "");
-  if (db && db[num]) return db[num];
   return db ? `ASN ${num}` : `${asn} (loading...)`;
 }
 

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, memo, type CSSProperties } from "react";
+import { useState, useEffect, useMemo, useCallback, memo, type CSSProperties } from "react";
 import type {
   DashboardCountry,
   DashboardASN,
@@ -8,6 +8,23 @@ import { fetchASNs } from "../api/client";
 
 interface BanditArmsOverviewProps {
   countries: DashboardCountry[];
+}
+
+// Lazy-loaded ASN → org name database (121K entries, ~1.5MB gzipped)
+let asnNamesDB: Record<string, string> | null = null;
+let asnNamesLoading = false;
+
+function useASNNames() {
+  const [loaded, setLoaded] = useState(asnNamesDB !== null);
+  useEffect(() => {
+    if (asnNamesDB || asnNamesLoading) return;
+    asnNamesLoading = true;
+    fetch("/asn-names.json")
+      .then((r) => r.json())
+      .then((data) => { asnNamesDB = data; setLoaded(true); })
+      .catch(() => { asnNamesLoading = false; });
+  }, []);
+  return loaded ? asnNamesDB : null;
 }
 
 const COUNTRY_NAMES: Record<string, string> = {
@@ -94,9 +111,9 @@ const ASN_NAMES: Record<string, string> = {
   AS2856: "BT", AS6461: "Zayo", AS174: "Cogent",
 };
 
-function asnDisplayName(asn: string): string {
+function asnDisplayName(asn: string, db: Record<string, string> | null): string {
   if (ASN_NAMES[asn]) return ASN_NAMES[asn];
-  // Format unknown ASNs more readably: "AS44244" → "ASN 44244"
+  if (db?.[asn]) return db[asn];
   const num = asn.replace(/^AS/i, "");
   return `ASN ${num}`;
 }
@@ -264,10 +281,10 @@ function ArmRow({ arm }: { arm: DashboardArmEntry }) {
   );
 }
 
-function ISPSection({ asn, country, expandedASNs, toggleASN }: { asn: DashboardASN; country: string; expandedASNs: Set<string>; toggleASN: (key: string) => void }) {
+function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB }: { asn: DashboardASN; country: string; expandedASNs: Set<string>; toggleASN: (key: string) => void; asnDB: Record<string, string> | null }) {
   const key = `${country}-${asn.asn}`;
   const expanded = expandedASNs.has(key);
-  const name = asnDisplayName(asn.asn);
+  const name = asnDisplayName(asn.asn, asnDB);
   const blockedColor = asn.numBlocked > 0 ? "#e06060" : "#667080";
 
   return (
@@ -299,6 +316,7 @@ function ISPSection({ asn, country, expandedASNs, toggleASN }: { asn: DashboardA
 }
 
 function BanditArmsOverview({ countries }: BanditArmsOverviewProps) {
+  const asnDB = useASNNames();
   const [expandedCountries, setExpandedCountries] = useState<Set<string>>(new Set());
   const [expandedASNs, setExpandedASNs] = useState<Set<string>>(new Set());
   const [asnCache, setAsnCache] = useState<Map<string, DashboardASN[]>>(new Map());
@@ -449,6 +467,7 @@ function BanditArmsOverview({ countries }: BanditArmsOverviewProps) {
                       country={c.country}
                       expandedASNs={expandedASNs}
                       toggleASN={toggleASN}
+                      asnDB={asnDB}
                     />
                   ))}
                 </div>

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -1,0 +1,392 @@
+import { useState, useMemo, useCallback, memo, type CSSProperties } from "react";
+import type {
+  DashboardCountry,
+  DashboardASN,
+  DashboardArmEntry,
+} from "../api/client";
+import { fetchASNs } from "../api/client";
+
+interface BanditArmsOverviewProps {
+  countries: DashboardCountry[];
+}
+
+const ASN_NAMES: Record<string, string> = {
+  AS44244: "Irancell",
+  AS197207: "MCI",
+  AS58224: "TCI",
+  AS12880: "Afranet",
+  AS4134: "China Telecom",
+  AS4837: "China Unicom",
+  AS9808: "China Mobile",
+  AS12389: "Rostelecom",
+  AS25513: "PJSC MTS",
+  AS8359: "MTS OJSC",
+};
+
+function asnDisplayName(asn: string): string {
+  return ASN_NAMES[asn] ?? asn;
+}
+
+function blockRateColor(rate: number): string {
+  if (rate > 0.3) return "#e0a080";
+  if (rate > 0.1) return "#d8c090";
+  return "#a0c8a0";
+}
+
+function successRateColor(rate: number): string {
+  if (rate > 0.8) return "#a0c8a0";
+  if (rate > 0.5) return "#d8c090";
+  return "#e0a080";
+}
+
+function MiniBar({ value, color }: { value: number; color: string }) {
+  const clamped = Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
+  return (
+    <div style={{ flex: 1, height: "3px", background: "#ffffff08", borderRadius: "2px", overflow: "hidden" }}>
+      <div style={{ height: "100%", width: `${clamped * 100}%`, background: color, opacity: 0.5, borderRadius: "2px" }} />
+    </div>
+  );
+}
+
+const card: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  padding: "1rem 1.1rem",
+  minWidth: 0,
+  flex: "1 1 0",
+};
+
+const cardLabel: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.6rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "#8890a0",
+  marginBottom: "0.3rem",
+};
+
+const cardValue: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "1.6rem",
+  fontWeight: 600,
+  lineHeight: 1.15,
+};
+
+const countryHeaderStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.6rem",
+  padding: "0.6rem 0.75rem",
+  cursor: "pointer",
+  userSelect: "none",
+  borderBottom: "1px solid #ffffff06",
+  background: "rgba(255,255,255,0.015)",
+  transition: "background 0.15s",
+};
+
+const ispRowStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  padding: "0.45rem 0.75rem 0.45rem 1.5rem",
+  cursor: "pointer",
+  userSelect: "none",
+  borderBottom: "1px solid #ffffff04",
+  background: "rgba(255,255,255,0.008)",
+  transition: "background 0.15s",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.65rem",
+  color: "#c0c8d4",
+};
+
+const armRowStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  padding: "0.35rem 0.75rem 0.35rem 2.5rem",
+  borderBottom: "1px solid #ffffff03",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.6rem",
+  color: "#a0a8b8",
+};
+
+const chipStyle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.5rem",
+  padding: "0.1rem 0.4rem",
+  borderRadius: "3px",
+  background: "#ffffff08",
+  color: "#8890a0",
+  whiteSpace: "nowrap",
+};
+
+const blockedBadge: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.48rem",
+  padding: "0.1rem 0.35rem",
+  borderRadius: "3px",
+  background: "#e0606020",
+  color: "#e06060",
+  textTransform: "uppercase",
+  letterSpacing: "0.03em",
+  whiteSpace: "nowrap",
+};
+
+const chevronStyle = (expanded: boolean): CSSProperties => ({
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.55rem",
+  color: "#667080",
+  width: "1rem",
+  textAlign: "center",
+  transition: "transform 0.15s",
+  transform: expanded ? "rotate(0deg)" : "rotate(-90deg)",
+  flexShrink: 0,
+});
+
+function ArmRow({ arm }: { arm: DashboardArmEntry }) {
+  const sr = arm.successRate ?? (arm.totalTests && arm.totalTests > 0 ? (arm.successCount ?? 0) / arm.totalTests : undefined);
+  const hasTests = arm.totalTests != null && arm.totalTests > 0;
+  const srColor = sr != null ? successRateColor(sr) : "#667080";
+  const label = [arm.trackName, arm.regionName].filter(Boolean).join(" · ") || arm.armId;
+
+  return (
+    <div style={armRowStyle}>
+      <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: "1 1 auto" }}>
+        {label}
+      </span>
+
+      {hasTests && sr != null && (
+        <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px", flexShrink: 0 }}>
+          <MiniBar value={sr} color={srColor} />
+          <span style={{ color: srColor, fontSize: "0.5rem", minWidth: "28px", textAlign: "right" }}>
+            {Math.round(sr * 100)}%
+          </span>
+        </div>
+      )}
+
+      {hasTests && (
+        <span style={{ ...chipStyle, fontSize: "0.48rem" }}>
+          {arm.totalTests} tests
+        </span>
+      )}
+
+      {arm.selectionProbability != null && (
+        <span style={{ ...chipStyle, fontSize: "0.48rem" }}>
+          P={Math.round(arm.selectionProbability * 100)}%
+        </span>
+      )}
+
+      {arm.routeCount != null && (
+        <span style={{ ...chipStyle, fontSize: "0.48rem" }}>
+          {arm.routeCount} route{arm.routeCount !== 1 ? "s" : ""}
+        </span>
+      )}
+
+      {arm.blocked && (
+        <span style={blockedBadge}>blocked</span>
+      )}
+    </div>
+  );
+}
+
+function ISPSection({ asn, country, expandedASNs, toggleASN }: { asn: DashboardASN; country: string; expandedASNs: Set<string>; toggleASN: (key: string) => void }) {
+  const key = `${country}-${asn.asn}`;
+  const expanded = expandedASNs.has(key);
+  const name = asnDisplayName(asn.asn);
+  const blockedColor = asn.numBlocked > 0 ? "#e06060" : "#667080";
+
+  return (
+    <div>
+      <div
+        style={ispRowStyle}
+        onClick={() => toggleASN(key)}
+        onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.02)"; }}
+        onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.008)"; }}
+      >
+        <span style={chevronStyle(expanded)}>&#9662;</span>
+        <span style={{ fontWeight: 600, color: "#c0c8d4" }}>{name}</span>
+        {name !== asn.asn && (
+          <span style={{ fontSize: "0.5rem", color: "#667080" }}>{asn.asn}</span>
+        )}
+        <span style={{ marginLeft: "auto", display: "flex", gap: "0.5rem", alignItems: "center" }}>
+          <span style={chipStyle}>{asn.numArms} arms</span>
+          <span style={{ ...chipStyle, color: blockedColor }}>{asn.numBlocked} blocked</span>
+          <span style={chipStyle}>{asn.totalPulls.toLocaleString()} pulls</span>
+        </span>
+      </div>
+      {expanded && asn.topArms && asn.topArms.length > 0 && (
+        <div>
+          {asn.topArms.map((arm) => (
+            <ArmRow key={arm.armId} arm={arm} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BanditArmsOverview({ countries }: BanditArmsOverviewProps) {
+  const [expandedCountries, setExpandedCountries] = useState<Set<string>>(new Set());
+  const [expandedASNs, setExpandedASNs] = useState<Set<string>>(new Set());
+  const [asnCache, setAsnCache] = useState<Map<string, DashboardASN[]>>(new Map());
+  const [loadingCountries, setLoadingCountries] = useState<Set<string>>(new Set());
+
+  const sorted = useMemo(
+    () => [...countries].sort((a, b) => b.asnCount - a.asnCount),
+    [countries],
+  );
+
+  const totalASNs = useMemo(() => countries.reduce((s, c) => s + c.asnCount, 0), [countries]);
+
+  const weightedBlockRate = useMemo(() => {
+    const totalWeight = countries.reduce((s, c) => s + c.asnCount, 0);
+    if (totalWeight === 0) return 0;
+    return countries.reduce((s, c) => s + c.avgBlockRate * c.asnCount, 0) / totalWeight;
+  }, [countries]);
+
+  const weightedEntropy = useMemo(() => {
+    const totalWeight = countries.reduce((s, c) => s + c.asnCount, 0);
+    if (totalWeight === 0) return 0;
+    return countries.reduce((s, c) => s + c.avgEntropy * c.asnCount, 0) / totalWeight;
+  }, [countries]);
+
+  const toggleCountry = useCallback(async (countryCode: string) => {
+    setExpandedCountries((prev) => {
+      const next = new Set(prev);
+      if (next.has(countryCode)) {
+        next.delete(countryCode);
+        return next;
+      }
+      next.add(countryCode);
+      return next;
+    });
+
+    if (!asnCache.has(countryCode) && !loadingCountries.has(countryCode)) {
+      setLoadingCountries((prev) => new Set(prev).add(countryCode));
+      try {
+        const data = await fetchASNs(countryCode);
+        setAsnCache((prev) => new Map(prev).set(countryCode, data));
+      } catch {
+        setAsnCache((prev) => new Map(prev).set(countryCode, []));
+      } finally {
+        setLoadingCountries((prev) => {
+          const next = new Set(prev);
+          next.delete(countryCode);
+          return next;
+        });
+      }
+    }
+  }, [asnCache, loadingCountries]);
+
+  const toggleASN = useCallback((key: string) => {
+    setExpandedASNs((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  if (countries.length === 0) {
+    return (
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", minHeight: 300, color: "#667080", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
+        No bandit data available
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.75rem", overflowY: "auto", padding: "0.75rem", background: "var(--bg-card)" }}>
+      {/* Summary Cards */}
+      <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
+        <div style={card}>
+          <div style={cardLabel}>Countries</div>
+          <div style={{ ...cardValue, color: "#00e5c8" }}>{countries.length}</div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Total ASNs</div>
+          <div style={{ ...cardValue, color: "#c0c8d4" }}>{totalASNs}</div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Avg Block Rate</div>
+          <div style={{ ...cardValue, color: blockRateColor(weightedBlockRate) }}>
+            {(weightedBlockRate * 100).toFixed(1)}%
+          </div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Avg Entropy</div>
+          <div style={{ ...cardValue, color: "#a0b0c8" }}>
+            {weightedEntropy.toFixed(3)}
+          </div>
+        </div>
+      </div>
+
+      {/* Country list */}
+      <div style={{ background: "var(--bg-card)", borderRadius: "var(--radius-md)", border: "1px solid #ffffff08", overflow: "auto", flex: 1 }}>
+        {sorted.map((c) => {
+          const expanded = expandedCountries.has(c.country);
+          const loading = loadingCountries.has(c.country);
+          const asns = asnCache.get(c.country);
+          const brColor = blockRateColor(c.avgBlockRate);
+
+          return (
+            <div key={c.country}>
+              {/* Country header */}
+              <div
+                style={countryHeaderStyle}
+                onClick={() => toggleCountry(c.country)}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.03)"; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.015)"; }}
+              >
+                <span style={chevronStyle(expanded)}>&#9662;</span>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.75rem", fontWeight: 700, color: "#00e5c8" }}>
+                  {c.country}
+                </span>
+                <span style={chipStyle}>{c.asnCount} ASN{c.asnCount !== 1 ? "s" : ""}</span>
+
+                <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px" }}>
+                  <MiniBar value={c.avgBlockRate} color={brColor} />
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.5rem", color: brColor, minWidth: "30px", textAlign: "right" }}>
+                    {(c.avgBlockRate * 100).toFixed(1)}%
+                  </span>
+                </div>
+
+                <span style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: "0.5rem", color: "#8890a0" }}>
+                  H={c.avgEntropy.toFixed(3)}
+                </span>
+              </div>
+
+              {/* Expanded ISP list */}
+              {expanded && (
+                <div>
+                  {loading && (
+                    <div style={{ padding: "0.6rem 1.5rem", fontFamily: "var(--font-mono)", fontSize: "0.6rem", color: "#667080" }}>
+                      Loading ISPs...
+                    </div>
+                  )}
+                  {!loading && asns && asns.length === 0 && (
+                    <div style={{ padding: "0.6rem 1.5rem", fontFamily: "var(--font-mono)", fontSize: "0.6rem", color: "#667080" }}>
+                      No ASN data
+                    </div>
+                  )}
+                  {!loading && asns && asns.map((asn) => (
+                    <ISPSection
+                      key={asn.asn}
+                      asn={asn}
+                      country={c.country}
+                      expandedASNs={expandedASNs}
+                      toggleASN={toggleASN}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default memo(BanditArmsOverview);

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -433,7 +433,7 @@ function BanditArmsOverview({ countries }: BanditArmsOverviewProps) {
                 <span style={{ fontFamily: "var(--font-sans)", fontSize: "0.85rem", fontWeight: 700, color: "#00e5c8" }}>
                   {countryName(c.country)}
                 </span>
-                <span style={chipStyle}>{c.asnCount} ASN{c.asnCount !== 1 ? "s" : ""}</span>
+                <span style={chipStyle}>{asns ? asns.length : c.asnCount} ASN{(asns ? asns.length : c.asnCount) !== 1 ? "s" : ""}</span>
 
                 <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px" }}>
                   <MiniBar value={c.avgBlockRate} color={brColor} />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import ImpactCard from "./ImpactCard";
 import ProtocolFeed from "./ProtocolFeed";
 import ProxyWidget from "./ProxyWidget";
 import VPSOverview from "./VPSOverview";
+import BanditArmsOverview from "./BanditArmsOverview";
 import type { GlobalStats } from "../data/mock";
 
 function LanternLogo() {
@@ -31,12 +32,15 @@ function LanternLogo() {
 export default function Dashboard() {
   const { isAuthenticated, user, logout } = useAuth();
   const { globalStats, dataCenters, activityEvents, trafficFlows, volunteerStats, isLive, blockedRoutes, demoMode, toggleDemoMode } = useLiveData();
-  const [activeTab, setActiveTab] = useState<'map' | 'vps'>(() => {
-    return window.location.hash === '#vps' ? 'vps' : 'map';
+  const [activeTab, setActiveTab] = useState<'map' | 'vps' | 'arms'>(() => {
+    const hash = window.location.hash;
+    if (hash === '#vps') return 'vps';
+    if (hash === '#arms') return 'arms';
+    return 'map';
   });
-  const switchTab = useCallback((tab: 'map' | 'vps') => {
+  const switchTab = useCallback((tab: 'map' | 'vps' | 'arms') => {
     setActiveTab(tab);
-    window.location.hash = tab === 'vps' ? '#vps' : '';
+    window.location.hash = tab === 'map' ? '' : `#${tab}`;
   }, []);
   const vpsData = useVPSData(activeTab === 'vps');
   const proxy = useProxy();
@@ -111,7 +115,7 @@ export default function Dashboard() {
           </div>
         </div>
         <div style={{ display: "flex", gap: "0.25rem", marginLeft: "1.5rem" }}>
-          {(["map", "vps"] as const).map((tab) => (
+          {(["map", "vps", "arms"] as const).map((tab) => (
             <div
               key={tab}
               onClick={() => switchTab(tab)}
@@ -129,7 +133,7 @@ export default function Dashboard() {
                 letterSpacing: "0.05em",
               }}
             >
-              {tab === "map" ? "Map" : "VPS Fleet"}
+              {tab === "map" ? "Map" : tab === "vps" ? "VPS Fleet" : "Bandit Arms"}
             </div>
           ))}
         </div>
@@ -208,6 +212,8 @@ export default function Dashboard() {
             isLoading={vpsData.isLoading}
             error={vpsData.error}
           />
+        ) : activeTab === "arms" ? (
+          <BanditArmsOverview countries={globalStats.countries} />
         ) : (
         <div className="map-section">
           <div className="map-header">


### PR DESCRIPTION
## Summary
New **Bandit Arms** tab (`#arms`) showing all countries with bandit data, expandable to ISPs and their arm assignments.

### Features
- 3-level collapsible hierarchy: Country → ISP → Arms
- Full country names (Iran, China, etc.) instead of codes
- ISP names from 121K-entry ASN database (ipverse/as-metadata, CC0 license)
  - Loaded lazily as `/asn-names.json` (~1.5MB gzipped) on first tab visit
- Per-arm: track + region, success rate bar, test count, selection probability, route count, blocked badge
- Summary cards with explanatory hints (what entropy means, what block rate means)
- ASN counts update from fetched data when country is expanded
- URL permalink: `#arms`

### Changes
- `src/components/BanditArmsOverview.tsx` — new component (404 lines)
- `src/components/Dashboard.tsx` — third tab + conditional rendering
- `public/asn-names.json` — 121K ASN→org name database

🤖 Generated with [Claude Code](https://claude.com/claude-code)