### PR TITLE
fix: pre-fetch ASN data for accurate counts on Arms tab

### DIFF
--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -363,6 +363,17 @@ function BanditArmsOverview({ countries }: BanditArmsOverviewProps) {
     return countries.reduce((s, c) => s + c.avgEntropy * c.asnCount, 0) / totalWeight;
   }, [countries]);
 
+  // Pre-fetch ASN data for all countries on mount for accurate counts
+  useEffect(() => {
+    for (const c of countries) {
+      if (!asnCache.has(c.country)) {
+        fetchASNs(c.country)
+          .then((data) => setAsnCache((prev) => new Map(prev).set(c.country, data)))
+          .catch(() => {});
+      }
+    }
+  }, [countries]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const toggleCountry = useCallback(async (countryCode: string) => {
     setExpandedCountries((prev) => {
       const next = new Set(prev);


### PR DESCRIPTION
## Summary
Auto-fetch ASN data for all countries on mount instead of waiting for user clicks. Fixes the total and per-country ASN counts showing stale numbers from the global endpoint until countries are manually expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)