### PR TITLE
feat: show VPS count, user assignments, routes/client on arm rows

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -69,6 +69,9 @@ export interface DashboardArmEntry {
   successCount?: number;
   totalTests?: number;
   successRate?: number;
+  activeVps?: number;
+  totalAssignments?: number;
+  routesPerClient?: number;
 }
 
 export interface DashboardASN {

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -328,10 +328,26 @@ function ArmRow({ arm, regionToCity }: { arm: DashboardArmEntry; regionToCity?: 
         </Tip>
       )}
 
-      {arm.routeCount != null && (
-        <Tip text="Number of active VPS/proxy routes available in this arm.">
+      {arm.activeVps != null && arm.activeVps > 0 && (
+        <Tip text="Number of active VPS instances running in this arm (region+protocol combination). Each VPS can serve multiple clients.">
           <span style={chipStyle}>
-            {arm.routeCount} route{arm.routeCount !== 1 ? "s" : ""} <InfoIcon />
+            {arm.activeVps} VPS <InfoIcon />
+          </span>
+        </Tip>
+      )}
+
+      {arm.totalAssignments != null && arm.totalAssignments > 0 && (
+        <Tip text="Total number of client assignments across all VPS routes in this arm. Each client gets one or more routes from this arm.">
+          <span style={chipStyle}>
+            {arm.totalAssignments} user{arm.totalAssignments !== 1 ? "s" : ""} <InfoIcon />
+          </span>
+        </Tip>
+      )}
+
+      {arm.routesPerClient != null && arm.routesPerClient > 0 && (
+        <Tip text="How many routes from this arm each client receives. More routes per client means better redundancy if one route gets blocked.">
+          <span style={chipStyle}>
+            {arm.routesPerClient}/client <InfoIcon />
           </span>
         </Tip>
       )}


### PR DESCRIPTION
## Summary
Add three new metrics to each arm row on the Bandit Arms tab:
- **VPS count**: active VPS instances in this arm
- **Users**: total client assignments across all routes
- **Routes/client**: how many routes each client receives

Each chip has an ⓘ info icon with tooltip. Requires [lantern-cloud PR #2421](https://github.com/getlantern/lantern-cloud/pull/2421) for backend enrichment.

## Test plan
- [ ] Expand an ISP on the arms tab — arm rows show new chips
- [ ] Tooltips explain each metric on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)