### PR TITLE
feat: show active devices (HLL) instead of stale assignments

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -70,7 +70,7 @@ export interface DashboardArmEntry {
   totalTests?: number;
   successRate?: number;
   activeVps?: number;
-  totalAssignments?: number;
+  activeDevices?: number;
   routesPerClient?: number;
 }
 

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -336,10 +336,10 @@ function ArmRow({ arm, regionToCity }: { arm: DashboardArmEntry; regionToCity?: 
         </Tip>
       )}
 
-      {arm.totalAssignments != null && arm.totalAssignments > 0 && (
-        <Tip text="Total number of client assignments across all VPS routes in this arm. Each client gets one or more routes from this arm.">
+      {arm.activeDevices != null && arm.activeDevices > 0 && (
+        <Tip text="Approximate number of unique devices that have successfully connected through routes in this arm in the last 24 hours, tracked via HyperLogLog.">
           <span style={chipStyle}>
-            {arm.totalAssignments} user{arm.totalAssignments !== 1 ? "s" : ""} <InfoIcon />
+            {arm.activeDevices} device{arm.activeDevices !== 1 ? "s" : ""} <InfoIcon />
           </span>
         </Tip>
       )}


### PR DESCRIPTION
Replace `totalAssignments` with `activeDevices` from the HLL-based unique device tracking. Label: 'X devices'. Requires [lantern-cloud PR #2427](https://github.com/getlantern/lantern-cloud/pull/2427).