### PR TITLE
feat: use consolidated API endpoints, reduce polling from 4 to 2 calls

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -114,7 +114,21 @@ export interface DashboardInfraResponse {
   dataCenters: DashboardDataCenter[];
 }
 
+// ── Consolidated overview response ──
+
+export interface DashboardOverviewResponse {
+  countries: DashboardCountry[];
+  blockedCount: number;
+  blockedRoutes: string[];
+  trafficFlows: DashboardTrafficFlow[];
+}
+
 // ── API calls ──
+
+/** Single call for the overview page: countries, blocked routes, and traffic flows. */
+export function fetchOverview(): Promise<DashboardOverviewResponse> {
+  return apiFetch("/overview");
+}
 
 export function fetchGlobalStats(): Promise<DashboardGlobalStats> {
   return apiFetch("/global");
@@ -124,16 +138,10 @@ export function fetchASNs(country: string): Promise<DashboardASN[]> {
   return apiFetch("/asns", { country });
 }
 
-export function fetchASNHistory(asn: string): Promise<DashboardASN[]> {
-  return apiFetch("/asn-history", { asn });
-}
-
-export function fetchBlockedRoutes(): Promise<string[]> {
-  return apiFetch("/blocked-routes");
-}
-
-export function fetchInfrastructure(): Promise<DashboardInfraResponse> {
-  return apiFetch("/infrastructure");
+export function fetchInfrastructure(includeRoutes?: boolean): Promise<DashboardInfraResponse & { vpsRoutes?: DashboardVPSRoutesResponse }> {
+  const params: Record<string, string> = {};
+  if (includeRoutes) params.include_routes = "true";
+  return apiFetch("/infrastructure", params);
 }
 
 export const EventType = {

--- a/src/hooks/useLiveData.ts
+++ b/src/hooks/useLiveData.ts
@@ -1,9 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import {
-  fetchGlobalStats,
-  fetchBlockedRoutes,
+  fetchOverview,
   fetchInfrastructure,
-  fetchTrafficFlows,
   getStreamURL,
   type DashboardCountry,
   type DashboardDataCenter,
@@ -45,33 +43,32 @@ export function useLiveData() {
     if (!isAuthenticated || demoMode) return;
 
     try {
-      const [global, blocked, infra, flows] = await Promise.allSettled([
-        fetchGlobalStats(),
-        fetchBlockedRoutes(),
+      // Two calls instead of four: /overview (countries + blocked + flows)
+      // and /infrastructure (data centers).
+      const [overview, infra] = await Promise.allSettled([
+        fetchOverview(),
         fetchInfrastructure(),
-        fetchTrafficFlows(),
       ]);
 
-      if (global.status !== "fulfilled" || blocked.status !== "fulfilled") {
-        throw global.status === "rejected" ? global.reason : blocked.status === "rejected" ? blocked.reason : new Error("API error");
+      if (overview.status !== "fulfilled") {
+        throw overview.reason;
       }
 
       if (infra.status === "fulfilled") setDataCenters(infra.value.dataCenters);
-      if (flows.status === "fulfilled") setTrafficFlows(flows.value.flows);
 
-      const globalData = global.value;
-      const blockedData = blocked.value;
-      const totalASNs = globalData.countries.reduce((sum, c) => sum + c.asnCount, 0);
+      const data = overview.value;
+      const totalASNs = data.countries.reduce((sum, c) => sum + c.asnCount, 0);
 
       setGlobalStats((prev) => ({
         ...prev,
         activeUsers: totalASNs > 0 ? totalASNs * 50 : prev.activeUsers,
-        countriesReached: globalData.countries.length,
-        blocksEvadedToday: globalData.blockedCount > 0 ? globalData.blockedCount : prev.blocksEvadedToday,
-        countries: globalData.countries,
+        countriesReached: data.countries.length,
+        blocksEvadedToday: data.blockedCount > 0 ? data.blockedCount : prev.blocksEvadedToday,
+        countries: data.countries,
       }));
 
-      setBlockedRoutes(blockedData);
+      setBlockedRoutes(data.blockedRoutes);
+      setTrafficFlows(data.trafficFlows);
       setIsLive(true);
       setError(null);
     } catch (err) {

--- a/src/hooks/useVPSData.ts
+++ b/src/hooks/useVPSData.ts
@@ -17,11 +17,16 @@ export function useVPSData(enabled: boolean) {
       setIsLoading(true);
       try {
         const data = await fetchInfrastructure(true);
-        if (!cancelled && data.vpsRoutes) {
-          setRoutes(data.vpsRoutes.routes);
-          setSummary(data.vpsRoutes.summary);
-          setError(null);
+        if (cancelled) return;
+        if (!data.vpsRoutes) {
+          setRoutes([]);
+          setSummary(null);
+          setError("VPS route data unavailable");
+          return;
         }
+        setRoutes(data.vpsRoutes.routes);
+        setSummary(data.vpsRoutes.summary);
+        setError(null);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load VPS data");
       } finally {

--- a/src/hooks/useVPSData.ts
+++ b/src/hooks/useVPSData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { fetchVPSRoutes, type DashboardVPSRoute, type DashboardVPSSummary } from "../api/client";
+import { fetchInfrastructure, type DashboardVPSRoute, type DashboardVPSSummary } from "../api/client";
 import { useAuth } from "./useAuth";
 
 export function useVPSData(enabled: boolean) {
@@ -16,10 +16,10 @@ export function useVPSData(enabled: boolean) {
     const refresh = async () => {
       setIsLoading(true);
       try {
-        const data = await fetchVPSRoutes();
-        if (!cancelled) {
-          setRoutes(data.routes);
-          setSummary(data.summary);
+        const data = await fetchInfrastructure(true);
+        if (!cancelled && data.vpsRoutes) {
+          setRoutes(data.vpsRoutes.routes);
+          setSummary(data.vpsRoutes.summary);
           setError(null);
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- Use new `/overview` endpoint (countries + blocked routes + traffic flows in one call)
- `useLiveData` makes 2 HTTP calls per refresh instead of 4
- `useVPSData` uses `/infrastructure?include_routes=true` instead of separate `/vps-routes`
- Remove unused `fetchASNHistory`, `fetchBlockedRoutes`, `fetchTrafficFlows` calls

## Backend PR
getlantern/lantern-cloud#2436 — adds `/overview` endpoint and `?include_routes=true`

## Test plan
- [ ] Dashboard overview page loads correctly with consolidated data
- [ ] VPS tab shows route details
- [ ] No stale data after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)