### PR TITLE
fix: show '(top N shown)' when arms are truncated

### DIFF
--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -379,7 +379,7 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
         <span style={{ fontWeight: 600, color: "#c0c8d4" }}>{name}</span>
         <span style={{ fontSize: "0.65rem", color: "#667080" }}>{name !== asn.asn ? asn.asn : ""}</span>
         <span style={{ marginLeft: "auto", display: "flex", gap: "0.5rem", alignItems: "center" }}>
-          <span style={chipStyle}>{asn.numArms} arms</span>
+          <span style={chipStyle}>{asn.numArms} arms{asn.topArms.length < asn.numArms ? ` (top ${asn.topArms.length} shown)` : ""}</span>
           <Tip text="Arms where connections are failing vs total arms. Could be censorship, network issues, or server problems.">
             <span style={{ ...chipStyle, color: blockedColor }}>
               {asn.numBlocked}/{asn.numArms} blocked <InfoIcon />


### PR DESCRIPTION
## Summary
The snapshot stores up to 10 arms by weight, but `numArms` reflects the total count in EXP3 state. When an ASN has more than 10 arms, the label now shows e.g. "17 arms (top 10 shown)" instead of just "17 arms" with only 10 visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)