### PR TITLE
fix: accurate tooltip for probe observation counts

### DIFF
--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -313,7 +313,7 @@ function ArmRow({ arm, regionToCity }: { arm: DashboardArmEntry; regionToCity?: 
       )}
 
       {hasTests && (
-        <Tip text={`${arm.successCount ?? 0} of ${arm.totalTests} probe callbacks succeeded. The bandit marks an arm as "blocked" when the success rate drops below 10%.`}>
+        <Tip text={`${arm.successCount ?? 0} of ${arm.totalTests} first probe observations succeeded (1-hour rolling window). Each observation is either a probe's first callback (success if reward > 0.1) or a reaper expiration (always failure — probe never received any callback within 10 minutes). Repeat callbacks are not counted here. The bandit marks an arm as "blocked" when the success rate drops below 15%.`}>
           <span style={chipStyle}>
             {arm.successCount ?? 0}/{arm.totalTests} ok <InfoIcon />
           </span>


### PR DESCRIPTION
## Summary
The success/total chip tooltip previously said "probe callbacks succeeded" which was inaccurate. Updated to explain:
- These are first probe observations (first callback OR reaper expiration) in a 1-hour rolling window
- Success = first callback with reward > 0.1
- Failure = reaper expiration (probe never received any callback within 10 min)
- Repeat callbacks are not counted
- Blocking threshold is 15% (was incorrectly stated as 10%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)