### PR TITLE
fix: update tooltip reaper expiry to 30s

### DIFF
--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -313,7 +313,7 @@ function ArmRow({ arm, regionToCity }: { arm: DashboardArmEntry; regionToCity?: 
       )}
 
       {hasTests && (
-        <Tip text={`${arm.successCount ?? 0} of ${arm.totalTests} first probe observations succeeded (1-hour rolling window). Each observation is either a probe's first callback (success if reward > 0.1) or a reaper expiration (always failure — probe never received any callback within 10 minutes). Repeat callbacks are not counted here. The bandit marks an arm as "blocked" when the success rate drops below 15%.`}>
+        <Tip text={`${arm.successCount ?? 0} of ${arm.totalTests} first probe observations succeeded (1-hour rolling window). Each observation is either a probe's first callback (success if reward > 0.1) or a reaper expiration (always failure — probe never received any callback within 30 seconds). Repeat callbacks are not counted here. The bandit marks an arm as "blocked" when the success rate drops below 15%.`}>
           <span style={chipStyle}>
             {arm.successCount ?? 0}/{arm.totalTests} ok <InfoIcon />
           </span>


### PR DESCRIPTION
Reaper cutoff changed from 10 minutes to 30 seconds in lantern-cloud#2456.