### PR TITLE
feat: AI system briefing panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -198,6 +198,131 @@
   max-height: 100%;
 }
 
+/* ── AI Summary Briefing ── */
+.ai-summary {
+  background: var(--bg-card);
+  padding: 0.875rem 1rem;
+  border-left: 3px solid var(--primary);
+  transition: border-left-color 0.6s ease;
+  animation: fade-in 0.4s ease-out both;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.ai-summary::-webkit-scrollbar { width: 4px; }
+.ai-summary::-webkit-scrollbar-thumb { background: var(--panel-border); border-radius: 2px; }
+.ai-summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.ai-summary-title {
+  font: 600 0.65rem/1 'IBM Plex Mono', monospace;
+  color: var(--text-muted);
+  letter-spacing: 0.12em;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.ai-summary-icon {
+  color: var(--primary);
+  font-size: 0.8rem;
+}
+.ai-summary-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.ai-summary-timestamp {
+  font: 400 0.6rem/1 'IBM Plex Mono', monospace;
+  color: var(--text-dim);
+}
+.ai-summary-refresh {
+  background: none;
+  border: 1px solid var(--panel-border);
+  color: var(--text-muted);
+  font: 600 0.65rem/1 'IBM Plex Mono', monospace;
+  padding: 0.2rem 0.4rem;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.ai-summary-refresh:hover:not(:disabled) {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+.ai-summary-refresh:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+.ai-summary-body {
+  font: 400 0.72rem/1.55 'Outfit', sans-serif;
+  color: var(--text-secondary);
+}
+.ai-summary-text p {
+  margin: 0 0 0.35rem;
+}
+.ai-summary-section {
+  font: 700 0.68rem/1.3 'IBM Plex Mono', monospace;
+  color: var(--text-primary);
+  margin: 0.6rem 0 0.25rem;
+  padding: 0;
+}
+.ai-summary-section:first-child {
+  margin-top: 0;
+}
+.ai-summary-bullet {
+  padding-left: 0.25rem;
+  margin-bottom: 0.2rem;
+  color: var(--text-secondary);
+}
+.ai-summary-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-dim);
+  font: 400 0.7rem/1 'IBM Plex Mono', monospace;
+}
+.ai-summary-pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--primary);
+  animation: pulse-dot 1.5s ease-in-out infinite;
+}
+@keyframes pulse-dot {
+  0%, 100% { opacity: 0.3; transform: scale(0.8); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+.ai-summary-cursor {
+  color: var(--primary);
+  animation: blink-cursor 0.8s step-end infinite;
+}
+@keyframes blink-cursor {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+.ai-summary-placeholder {
+  color: var(--text-dim);
+  font: 400 0.7rem/1 'IBM Plex Mono', monospace;
+}
+.ai-summary-error {
+  color: var(--danger);
+  font: 400 0.7rem/1.4 'IBM Plex Mono', monospace;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.ai-summary-retry {
+  background: none;
+  border: 1px solid var(--danger);
+  color: var(--danger);
+  font: 500 0.6rem/1 'IBM Plex Mono', monospace;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
 /* ── Your Impact Card ── */
 .impact-card {
   background: var(--bg-card);

--- a/src/components/AISummary.tsx
+++ b/src/components/AISummary.tsx
@@ -1,0 +1,222 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+
+const API_URL = import.meta.env.VITE_API_URL || "https://api.staging.iantem.io";
+
+interface SummaryData {
+  text: string;
+  generatedAt: string;
+  model: string;
+  cached: boolean;
+}
+
+type SummaryState = "idle" | "loading" | "streaming" | "complete" | "error";
+
+export default function AISummary({ authToken }: { authToken: string | null }) {
+  const [state, setState] = useState<SummaryState>("idle");
+  const [summary, setSummary] = useState<SummaryData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [cooldown, setCooldown] = useState(0);
+  const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startCooldown = useCallback(() => {
+    setCooldown(60);
+    if (cooldownRef.current) clearInterval(cooldownRef.current);
+    cooldownRef.current = setInterval(() => {
+      setCooldown((prev) => {
+        if (prev <= 1) {
+          clearInterval(cooldownRef.current!);
+          cooldownRef.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, []);
+
+  const fetchSummary = useCallback(async () => {
+    if (!authToken) return;
+    setState("loading");
+    setError(null);
+
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+    if (authToken) headers.Authorization = `Bearer ${authToken}`;
+
+    try {
+      // Try cached JSON endpoint first
+      const res = await fetch(`${API_URL}/v1/dashboard/ai-summary`, { headers });
+
+      if (res.ok) {
+        const data = await res.json();
+        setSummary({
+          text: data.summary,
+          generatedAt: data.generatedAt,
+          model: data.model,
+          cached: data.cached || false,
+        });
+        setState("complete");
+        startCooldown();
+        return;
+      }
+
+      if (res.status === 503) {
+        // AI not configured — try debug endpoint for raw data view
+        setState("error");
+        setError("AI summary not configured on server");
+        return;
+      }
+
+      // Fall through to streaming
+      streamSummary();
+    } catch {
+      // Network error — try streaming
+      streamSummary();
+    }
+  }, [authToken, startCooldown]);
+
+  const streamSummary = useCallback(() => {
+    if (!authToken) return;
+    setState("streaming");
+    setSummary({ text: "", generatedAt: "", model: "", cached: false });
+
+    const url = `${API_URL}/v1/dashboard/ai-summary/stream`;
+    const es = new EventSource(`${url}?token=${authToken}`);
+
+    es.addEventListener("summary", (e) => {
+      const data = JSON.parse(e.data);
+
+      if (data.type === "delta") {
+        setSummary((prev) =>
+          prev ? { ...prev, text: prev.text + data.text } : null,
+        );
+      } else if (data.type === "complete") {
+        setSummary({
+          text: data.text,
+          generatedAt: data.generatedAt,
+          model: data.model,
+          cached: false,
+        });
+        setState("complete");
+        startCooldown();
+        es.close();
+      } else if (data.type === "error") {
+        setError(data.error);
+        setState("error");
+        es.close();
+      }
+    });
+
+    es.onerror = () => {
+      setState((prev) => (prev === "streaming" ? "error" : prev));
+      setError("Connection lost");
+      es.close();
+    };
+  }, [authToken, startCooldown]);
+
+  // Fetch on mount
+  useEffect(() => {
+    if (authToken) fetchSummary();
+  }, [authToken]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const severityColor = useCallback(() => {
+    if (!summary?.text) return "var(--panel-border)";
+    const text = summary.text.toLowerCase();
+    if (
+      text.includes("critical") ||
+      text.includes("severe") ||
+      text.includes("emergency")
+    )
+      return "var(--danger)";
+    if (
+      text.includes("elevated") ||
+      text.includes("spike") ||
+      text.includes("actively blocking")
+    )
+      return "var(--secondary)";
+    return "var(--primary)";
+  }, [summary]);
+
+  const timeAgo = useCallback((dateStr: string) => {
+    if (!dateStr) return "";
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return "just now";
+    if (mins === 1) return "1 min ago";
+    return `${mins} min ago`;
+  }, []);
+
+  return (
+    <div className="ai-summary" style={{ borderLeftColor: severityColor() }}>
+      <div className="ai-summary-header">
+        <div className="ai-summary-title">
+          <span className="ai-summary-icon">&#x2726;</span>
+          SYSTEM BRIEFING
+        </div>
+        <div className="ai-summary-actions">
+          {summary?.generatedAt && (
+            <span className="ai-summary-timestamp">
+              {timeAgo(summary.generatedAt)}
+            </span>
+          )}
+          <button
+            className="ai-summary-refresh"
+            onClick={fetchSummary}
+            disabled={state === "loading" || state === "streaming" || cooldown > 0}
+            title={cooldown > 0 ? `Refresh in ${cooldown}s` : "Refresh summary"}
+          >
+            {cooldown > 0 ? `${cooldown}s` : "↻"}
+          </button>
+        </div>
+      </div>
+
+      <div className="ai-summary-body">
+        {state === "idle" && (
+          <div className="ai-summary-placeholder">Waiting for data...</div>
+        )}
+
+        {state === "loading" && (
+          <div className="ai-summary-loading">
+            <div className="ai-summary-pulse" />
+            Analyzing system state...
+          </div>
+        )}
+
+        {(state === "streaming" || state === "complete") && summary?.text && (
+          <div className="ai-summary-text">
+            {summary.text.split("\n").map((line, i) => {
+              if (line.startsWith("**") && line.endsWith("**")) {
+                return (
+                  <h4 key={i} className="ai-summary-section">
+                    {line.replace(/\*\*/g, "")}
+                  </h4>
+                );
+              }
+              if (line.startsWith("- ")) {
+                return (
+                  <div key={i} className="ai-summary-bullet">
+                    {line}
+                  </div>
+                );
+              }
+              if (line.trim() === "") return <br key={i} />;
+              return <p key={i}>{line}</p>;
+            })}
+            {state === "streaming" && (
+              <span className="ai-summary-cursor">&#x2588;</span>
+            )}
+          </div>
+        )}
+
+        {state === "error" && (
+          <div className="ai-summary-error">
+            {error || "Failed to generate summary"}
+            <button className="ai-summary-retry" onClick={fetchSummary}>
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -11,6 +11,7 @@ import ProtocolFeed from "./ProtocolFeed";
 import ProxyWidget from "./ProxyWidget";
 import VPSOverview from "./VPSOverview";
 import BanditArmsOverview from "./BanditArmsOverview";
+import AISummary from "./AISummary";
 import type { GlobalStats } from "../data/mock";
 
 function LanternLogo() {
@@ -30,7 +31,7 @@ function LanternLogo() {
 }
 
 export default function Dashboard() {
-  const { isAuthenticated, user, logout } = useAuth();
+  const { isAuthenticated, user, logout, token } = useAuth();
   const { globalStats, dataCenters, activityEvents, trafficFlows, volunteerStats, isLive, blockedRoutes, demoMode, toggleDemoMode } = useLiveData();
   const [activeTab, setActiveTab] = useState<'map' | 'vps' | 'arms'>(() => {
     const hash = window.location.hash;
@@ -308,6 +309,7 @@ export default function Dashboard() {
         )}
 
         <div className="right-panel">
+          <AISummary authToken={token} />
           <ProxyWidget {...proxy} />
           <ImpactCard stats={volunteerStats} />
           <ProtocolFeed liveEvents={activityEvents} demoMode={demoMode} />


### PR DESCRIPTION
## Summary

- Add `AISummary` component to the dashboard right panel (top position)
- Fetches natural language summaries from the new `/dashboard/ai-summary` endpoint
- Supports SSE streaming for fresh generation with token-by-token text appearance
- Dark theme styling with severity-based left border (green/amber/red)
- Manual refresh button with 60s cooldown

## Dependencies

Requires the lantern-cloud server-side changes (on `feat/bandit-k8s-arms` branch) and Anthropic API key in Vault.

## Test plan

- [ ] Verify component renders with loading state on mount
- [ ] With Vault secret configured: verify summary appears from Claude
- [ ] Without Vault secret: verify "AI summary not configured" error state
- [ ] Test streaming: SSE tokens appear incrementally with cursor
- [ ] Test refresh cooldown: button disabled for 60s after generation
- [ ] Verify scroll behavior for long summaries (max-height: 320px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)