### PR TITLE
feat: add SSH column to VPS route table + fix configuring color

### DIFF
--- a/src/components/VPSOverview.tsx
+++ b/src/components/VPSOverview.tsx
@@ -10,7 +10,7 @@ interface VPSOverviewProps {
 
 const STATUS_COLORS: Record<string, string> = {
   running: "#a0c8a0",
-  configuring: "#f0a030",
+  configuring: "#80b0e0",
   provisioning: "#f0a030",
   pending: "#667080",
 };
@@ -112,7 +112,7 @@ const trackHeaderStyle: CSSProperties = {
 
 const rowStyle: CSSProperties = {
   display: "grid",
-  gridTemplateColumns: "20px 1fr 0.7fr 0.6fr 0.5fr 0.6fr 0.5fr",
+  gridTemplateColumns: "20px 1fr 0.7fr 0.6fr 0.5fr 0.6fr 0.5fr 0.7fr",
   alignItems: "center",
   gap: "0.5rem",
   padding: "0.4rem 1rem 0.4rem 3rem",
@@ -298,6 +298,7 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
           <span>Uptime</span>
           <span>Assignments</span>
           <span>Status</span>
+          <span>SSH</span>
         </div>
 
         {regionGroups.map((region) => {
@@ -389,6 +390,30 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
                               {route.status}
                             </span>
                           )}
+                        </span>
+
+                        {/* SSH command */}
+                        <span
+                          title="Click to copy SSH command"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            const cmd = `ssh lantern@vps-${route.id.substring(0, 8)}`;
+                            navigator.clipboard.writeText(cmd);
+                            const el = e.currentTarget;
+                            el.style.color = "var(--accent-primary)";
+                            setTimeout(() => { el.style.color = "#667080"; }, 1000);
+                          }}
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.52rem",
+                            color: "#667080",
+                            cursor: "pointer",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          vps-{route.id.substring(0, 8)}
                         </span>
                       </div>
                     );


### PR DESCRIPTION
## Summary
- New **SSH** column in the VPS Fleet route table showing Tailscale hostname (`vps-XXXXXXXX`)
- Click the hostname to copy the full `ssh lantern@vps-XXXXXXXX` command to clipboard (flashes green on copy)
- Fix: configuring status color now matches the header (blue `#80b0e0` instead of orange `#f0a030`)

## Test plan
- [ ] VPS Fleet tab shows SSH column with truncated hostnames
- [ ] Click a hostname → clipboard contains `ssh lantern@vps-XXXXXXXX`
- [ ] Configuring routes show blue status badge, not orange

🤖 Generated with [Claude Code](https://claude.com/claude-code)