### PR TITLE
fix(feed): never label a callback event as "Probe Failed"

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -161,6 +161,7 @@ export interface DashboardActivityEvent {
   routeId?: string;
   detail?: string;
   reward?: number;
+  latencyMs?: number;
   timestamp: number;
 }
 

--- a/src/components/ProtocolFeed.tsx
+++ b/src/components/ProtocolFeed.tsx
@@ -44,7 +44,8 @@ const LIVE_CSS_CLASS: Record<string, string> = {
 // means the tunnel worked — the server treats it as a success for blocking
 // signals regardless of reward value. Reward just ranks arms for EXP3
 // weight updates: fast (~200ms) → 0.98, slow (~3s+) → ≈0.
-// We use the reward to color the feed — fast = green, slow = yellow — but
+// We use the reward to color the feed — fast uses the success/deployed
+// accent (green), slow uses the primary/generated accent (teal) — but
 // never label a callback-event as "failed" (no callback = no event at all).
 const CALLBACK_FAST_THRESHOLD = 0.5; // ~1500ms on the latency sigmoid
 
@@ -125,7 +126,7 @@ export default function ProtocolFeed({ liveEvents, demoMode }: ProtocolFeedProps
                 style={isCallback ? { opacity: 0.7 } : undefined}>
                 <div className={`feed-icon ${
                   isCallback
-                    ? (callbackFast ? "evaded" : "generated")
+                    ? (callbackFast ? "deployed" : "generated")
                     : (LIVE_CSS_CLASS[event.eventType] || "generated")
                 }`}>
                   {isCallback

--- a/src/components/ProtocolFeed.tsx
+++ b/src/components/ProtocolFeed.tsx
@@ -40,7 +40,13 @@ const LIVE_CSS_CLASS: Record<string, string> = {
   [EventType.CALLBACK]: "generated",
 };
 
-const CALLBACK_SUCCESS_THRESHOLD = 0.1;
+// Reward is a sigmoid of callback latency ∈ [0, 1]. ANY callback arriving
+// means the tunnel worked — the server treats it as a success for blocking
+// signals regardless of reward value. Reward just ranks arms for EXP3
+// weight updates: fast (~200ms) → 0.98, slow (~3s+) → ≈0.
+// We use the reward to color the feed — fast = green, slow = yellow — but
+// never label a callback-event as "failed" (no callback = no event at all).
+const CALLBACK_FAST_THRESHOLD = 0.5; // ~1500ms on the latency sigmoid
 
 function timeAgo(timestamp: number): string {
   const seconds = Math.floor((Date.now() - timestamp) / 1000);
@@ -111,23 +117,25 @@ export default function ProtocolFeed({ liveEvents, demoMode }: ProtocolFeedProps
         {useLive
           ? liveList.map((event, i) => {
               const isCallback = event.eventType === EventType.CALLBACK;
-              const callbackOk = isCallback && (event.reward ?? 0) > CALLBACK_SUCCESS_THRESHOLD;
+              const callbackFast = isCallback && (event.reward ?? 0) > CALLBACK_FAST_THRESHOLD;
+              const latencyMs = event.latencyMs ?? 0;
+              const latencySuffix = isCallback && latencyMs > 0 ? ` (${humanizeMs(`${latencyMs}ms`)})` : "";
               return (
               <div key={`${event.timestamp}-${i}`} className="feed-item"
                 style={isCallback ? { opacity: 0.7 } : undefined}>
                 <div className={`feed-icon ${
                   isCallback
-                    ? (callbackOk ? "evaded" : "blocked")
+                    ? (callbackFast ? "evaded" : "generated")
                     : (LIVE_CSS_CLASS[event.eventType] || "generated")
                 }`}>
                   {isCallback
-                    ? (callbackOk ? "✓" : "✗")
+                    ? (callbackFast ? "✓" : "⏱")
                     : (LIVE_TYPE_ICONS[event.eventType] || "📡")}
                 </div>
                 <div className="feed-content">
                   <div className="feed-title">
                     {isCallback
-                      ? `${callbackOk ? "Route OK" : "Probe Failed"}${event.trackName ? ` — ${event.trackName}` : ""}${event.regionName ? ` via ${event.regionName}` : ""}`
+                      ? `${callbackFast ? "Route OK" : "Route OK (slow)"}${event.trackName ? ` — ${event.trackName}` : ""}${event.regionName ? ` via ${event.regionName}` : ""}${latencySuffix}`
                       : `${LIVE_TYPE_LABELS[event.eventType] || event.eventType}${event.detail ? `: ${humanizeMs(event.detail)}` : ""}`}
                   </div>
                   <div className="feed-meta">


### PR DESCRIPTION
## Summary

Every CALLBACK event in the live feed means the tunnel worked — the API treats any callback arrival as a success (code comment at [callback.go:125](https://github.com/getlantern/lantern-cloud/blob/main/cmd/api/bandit/callback.go)). The \`reward\` field is a sigmoid of callback latency (200ms → 0.98, 1500ms → 0.5, 3000ms+ → ≈0) used only to rank arms for EXP3 weight updates.

The old label classified \`reward ≤ 0.1\` as **"Probe Failed"**, which is semantically wrong. Slow-but-working routes — most notably **Reflex**, which pays ~5s for the silence-timeout probe resistance — would ring up as failed even when every end-to-end request succeeded. This caused confusion during the Reflex rollout today.

## Before

| reward | label | color |
|--------|-------|-------|
| > 0.1 | Route OK | green |
| ≤ 0.1 | ✗ Probe Failed | red |

## After

| reward | label | icon |
|--------|-------|------|
| > 0.5 (~<1500ms) | Route OK | ✓ green |
| ≤ 0.5 | Route OK (slow) | ⏱ neutral |
| *(no callback)* | not in feed | — |

Also now shows the actual latency (\`latencyMs\` was already being returned by \`/dashboard/activity\` but wasn't in the TS interface).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Visual: slow Reflex callback shows "Route OK (slow) — reflex-linode-pro via US5 (6s)" with neutral ⏱ icon
- [ ] Visual: fast samizdat callback shows "Route OK — samizdat-pro-oci via ... (800ms)" with green ✓ icon