### PR TITLE
feat(arms): live per-ASN drill-in + region/protocol filter + success-rate sort

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -138,6 +138,21 @@ export function fetchASNs(country: string): Promise<DashboardASN[]> {
   return apiFetch("/asns", { country });
 }
 
+export interface DashboardASNArmsResponse {
+  asn: string;
+  country: string;
+  totalPulls: number;
+  fetchedAt: string;
+  arms: DashboardArmEntry[];
+}
+
+// fetchASNArms returns the full live EXP3 arm list for a single ASN, read
+// directly from Redis (not the snapshot table). Use this for the drill-in
+// view where all arms — including low-weight ones — matter.
+export function fetchASNArms(asn: string): Promise<DashboardASNArmsResponse> {
+  return apiFetch("/asn-arms", { asn });
+}
+
 export function fetchInfrastructure(includeRoutes?: boolean): Promise<DashboardInfraResponse & { vpsRoutes?: DashboardVPSRoutesResponse }> {
   const params: Record<string, string> = {};
   if (includeRoutes) params.include_routes = "true";

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -5,7 +5,7 @@ import type {
   DashboardArmEntry,
   DashboardDataCenter,
 } from "../api/client";
-import { fetchASNs } from "../api/client";
+import { fetchASNs, fetchASNArms } from "../api/client";
 
 interface BanditArmsOverviewProps {
   countries: DashboardCountry[];
@@ -367,6 +367,26 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
   const name = asnDisplayName(asn.asn, asnDB);
   const blockedColor = asn.numBlocked > 0 ? "#e06060" : "#667080";
 
+  // Live-fetched full arm set (vs snapshot top-N). Loaded on demand when the
+  // user clicks "Show all arms" — reads directly from Redis on the server,
+  // so it's fresher than the snapshot and uncapped.
+  const [allArms, setAllArms] = useState<DashboardArmEntry[] | null>(null);
+  const [loadingAll, setLoadingAll] = useState(false);
+  const [allArmsErr, setAllArmsErr] = useState<string | null>(null);
+
+  const loadAllArms = useCallback(() => {
+    setLoadingAll(true);
+    setAllArmsErr(null);
+    fetchASNArms(asn.asn)
+      .then((resp) => { setAllArms(resp.arms); })
+      .catch((e) => { setAllArmsErr(e instanceof Error ? e.message : String(e)); })
+      .finally(() => { setLoadingAll(false); });
+  }, [asn.asn]);
+
+  const displayedArms = allArms ?? asn.topArms;
+  const hasMoreBeyondSnapshot = asn.topArms.length < asn.numArms;
+  const showFullLoadButton = expanded && allArms === null && hasMoreBeyondSnapshot;
+
   return (
     <div>
       <div
@@ -379,7 +399,9 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
         <span style={{ fontWeight: 600, color: "#c0c8d4" }}>{name}</span>
         <span style={{ fontSize: "0.65rem", color: "#667080" }}>{name !== asn.asn ? asn.asn : ""}</span>
         <span style={{ marginLeft: "auto", display: "flex", gap: "0.5rem", alignItems: "center" }}>
-          <span style={chipStyle}>{asn.numArms} arms{asn.topArms.length < asn.numArms ? ` (top ${asn.topArms.length} shown)` : ""}</span>
+          <span style={chipStyle}>
+            {asn.numArms} arms{allArms ? ` (all shown, live)` : asn.topArms.length < asn.numArms ? ` (top ${asn.topArms.length} shown)` : ""}
+          </span>
           <Tip text="Arms where connections are failing vs total arms. Could be censorship, network issues, or server problems.">
             <span style={{ ...chipStyle, color: blockedColor }}>
               {asn.numBlocked}/{asn.numArms} blocked <InfoIcon />
@@ -388,11 +410,34 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
           <span style={chipStyle}>{asn.totalPulls.toLocaleString()} pulls</span>
         </span>
       </div>
-      {expanded && asn.topArms && asn.topArms.length > 0 && (
+      {expanded && displayedArms && displayedArms.length > 0 && (
         <div>
-          {asn.topArms.map((arm) => (
+          {displayedArms.map((arm) => (
             <ArmRow key={arm.armId} arm={arm} regionToCity={regionToCity} />
           ))}
+        </div>
+      )}
+      {showFullLoadButton && (
+        <div style={{ padding: "0.5rem 1rem", fontSize: "0.7rem" }}>
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); loadAllArms(); }}
+            disabled={loadingAll}
+            style={{
+              background: "transparent",
+              color: "#00e5c8",
+              border: "1px solid rgba(0,229,200,0.3)",
+              borderRadius: "4px",
+              padding: "0.3rem 0.75rem",
+              cursor: loadingAll ? "wait" : "pointer",
+              fontSize: "0.7rem",
+            }}
+          >
+            {loadingAll ? "Loading…" : `Show all ${asn.numArms} arms (live)`}
+          </button>
+          {allArmsErr && (
+            <span style={{ marginLeft: "0.75rem", color: "#e06060" }}>{allArmsErr}</span>
+          )}
         </div>
       )}
     </div>

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -265,6 +265,50 @@ const chipStyle: CSSProperties = {
   whiteSpace: "nowrap",
 };
 
+const filterBarStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.75rem",
+  alignItems: "center",
+  padding: "0.4rem 0.75rem",
+  background: "rgba(255,255,255,0.015)",
+  border: "1px solid #ffffff08",
+  borderRadius: "6px",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.65rem",
+  color: "#8890a0",
+  flexWrap: "wrap",
+};
+
+const filterLabelStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.35rem",
+  color: "#8890a0",
+};
+
+const selectStyle: CSSProperties = {
+  background: "var(--bg-card)",
+  color: "#c0c8d4",
+  border: "1px solid #ffffff14",
+  borderRadius: "4px",
+  padding: "0.2rem 0.4rem",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.65rem",
+  cursor: "pointer",
+};
+
+const clearButtonStyle: CSSProperties = {
+  background: "transparent",
+  color: "#00e5c8",
+  border: "1px solid rgba(0,229,200,0.25)",
+  borderRadius: "4px",
+  padding: "0.2rem 0.6rem",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.6rem",
+  cursor: "pointer",
+  marginLeft: "auto",
+};
+
 const blockedBadge: CSSProperties = {
   fontFamily: "var(--font-mono)",
   fontSize: "0.5rem",
@@ -361,7 +405,55 @@ function ArmRow({ arm, regionToCity }: { arm: DashboardArmEntry; regionToCity?: 
   );
 }
 
-function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity }: { asn: DashboardASN; country: string; expandedASNs: Set<string>; toggleASN: (key: string) => void; asnDB: Record<string, string> | null; regionToCity?: Map<string, string> }) {
+// Derive the protocol from a trackName like "reflex-linode-pro" or
+// "samizdat-pro-oci". First hyphen-separated segment is the protocol.
+function protocolFromTrackName(trackName: string | undefined): string {
+  if (!trackName) return "";
+  const idx = trackName.indexOf("-");
+  return idx > 0 ? trackName.substring(0, idx) : trackName;
+}
+
+type SortBy = "weight" | "successRate";
+
+function armSuccessRate(arm: DashboardArmEntry): number | null {
+  if (arm.successRate != null) return arm.successRate;
+  if (arm.totalTests != null && arm.totalTests > 0) {
+    return (arm.successCount ?? 0) / arm.totalTests;
+  }
+  return null;
+}
+
+interface ArmFilters {
+  region: string;   // empty = all
+  protocol: string; // empty = all
+  sortBy: SortBy;
+}
+
+function filterAndSortArms(arms: DashboardArmEntry[], f: ArmFilters): DashboardArmEntry[] {
+  let out = arms;
+  if (f.region) {
+    out = out.filter((a) => a.regionName === f.region);
+  }
+  if (f.protocol) {
+    out = out.filter((a) => protocolFromTrackName(a.trackName) === f.protocol);
+  }
+  if (f.sortBy === "successRate") {
+    // Arms with no test data sort to the bottom.
+    out = [...out].sort((a, b) => {
+      const ra = armSuccessRate(a);
+      const rb = armSuccessRate(b);
+      if (ra == null && rb == null) return b.weight - a.weight;
+      if (ra == null) return 1;
+      if (rb == null) return -1;
+      return rb - ra;
+    });
+  } else {
+    out = [...out].sort((a, b) => b.weight - a.weight);
+  }
+  return out;
+}
+
+function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity, filters }: { asn: DashboardASN; country: string; expandedASNs: Set<string>; toggleASN: (key: string) => void; asnDB: Record<string, string> | null; regionToCity?: Map<string, string>; filters: ArmFilters }) {
   const key = `${country}-${asn.asn}`;
   const expanded = expandedASNs.has(key);
   const name = asnDisplayName(asn.asn, asnDB);
@@ -389,7 +481,9 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
       .finally(() => { setLoadingAll(false); });
   }, [asn.asn]);
 
-  const displayedArms = allArms ?? asn.topArms;
+  const baseArms = allArms ?? asn.topArms;
+  const displayedArms = useMemo(() => filterAndSortArms(baseArms, filters), [baseArms, filters]);
+  const filtersActive = !!filters.region || !!filters.protocol || filters.sortBy !== "weight";
   const hasMoreBeyondSnapshot = asn.topArms.length < asn.numArms;
   const showFullLoadButton = expanded && allArms === null && hasMoreBeyondSnapshot;
 
@@ -416,11 +510,16 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
           <span style={chipStyle}>{asn.totalPulls.toLocaleString()} pulls</span>
         </span>
       </div>
-      {expanded && displayedArms && displayedArms.length > 0 && (
+      {expanded && displayedArms.length > 0 && (
         <div>
           {displayedArms.map((arm) => (
             <ArmRow key={arm.armId} arm={arm} regionToCity={regionToCity} />
           ))}
+        </div>
+      )}
+      {expanded && displayedArms.length === 0 && baseArms.length > 0 && filtersActive && (
+        <div style={{ padding: "0.5rem 1rem", fontSize: "0.7rem", color: "#667080" }}>
+          No arms match the current filters.
         </div>
       )}
       {showFullLoadButton && (
@@ -632,6 +731,35 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
   const [asnCache, setAsnCache] = useState<Map<string, DashboardASN[]>>(new Map());
   const [loadingCountries, setLoadingCountries] = useState<Set<string>>(new Set());
 
+  // Arm filter / sort state — applies to every expanded ASN's arm list.
+  const [regionFilter, setRegionFilter] = useState<string>("");
+  const [protocolFilter, setProtocolFilter] = useState<string>("");
+  const [sortBy, setSortBy] = useState<SortBy>("weight");
+  const armFilters: ArmFilters = useMemo(
+    () => ({ region: regionFilter, protocol: protocolFilter, sortBy }),
+    [regionFilter, protocolFilter, sortBy],
+  );
+
+  // Collect unique region names / protocol names across every arm we know
+  // about so the filter dropdowns stay current as the asn cache fills in.
+  const { availableRegions, availableProtocols } = useMemo(() => {
+    const regions = new Set<string>();
+    const protocols = new Set<string>();
+    for (const asnList of asnCache.values()) {
+      for (const asn of asnList) {
+        for (const arm of asn.topArms) {
+          if (arm.regionName) regions.add(arm.regionName);
+          const proto = protocolFromTrackName(arm.trackName);
+          if (proto) protocols.add(proto);
+        }
+      }
+    }
+    return {
+      availableRegions: Array.from(regions).sort(),
+      availableProtocols: Array.from(protocols).sort(),
+    };
+  }, [asnCache]);
+
   const sorted = useMemo(
     () => [...countries].sort((a, b) => b.asnCount - a.asnCount),
     [countries],
@@ -759,6 +887,58 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
         </Tip>
       </div>
 
+      {/* Arm filter / sort controls */}
+      <div style={filterBarStyle}>
+        <label style={filterLabelStyle}>
+          Region
+          <select
+            value={regionFilter}
+            onChange={(e) => setRegionFilter(e.target.value)}
+            style={selectStyle}
+          >
+            <option value="">All</option>
+            {availableRegions.map((r) => (
+              <option key={r} value={r}>
+                {regionToCity.get(r) ? `${regionToCity.get(r)} (${r})` : r}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={filterLabelStyle}>
+          Protocol
+          <select
+            value={protocolFilter}
+            onChange={(e) => setProtocolFilter(e.target.value)}
+            style={selectStyle}
+          >
+            <option value="">All</option>
+            {availableProtocols.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+        </label>
+        <label style={filterLabelStyle}>
+          Sort by
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as SortBy)}
+            style={selectStyle}
+          >
+            <option value="weight">Weight (default)</option>
+            <option value="successRate">Success rate</option>
+          </select>
+        </label>
+        {(regionFilter || protocolFilter || sortBy !== "weight") && (
+          <button
+            type="button"
+            onClick={() => { setRegionFilter(""); setProtocolFilter(""); setSortBy("weight"); }}
+            style={clearButtonStyle}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
       {/* Country list */}
       <div style={{ background: "var(--bg-card)", borderRadius: "var(--radius-md)", border: "1px solid #ffffff08", overflow: "auto", flex: 1 }}>
         {sorted.map((c) => {
@@ -823,6 +1003,7 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
                       toggleASN={toggleASN}
                       asnDB={asnDB}
                       regionToCity={regionToCity}
+                      filters={armFilters}
                     />
                   ))}
                 </div>

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -453,7 +453,7 @@ function filterAndSortArms(arms: DashboardArmEntry[], f: ArmFilters): DashboardA
   return out;
 }
 
-function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity, filters }: { asn: DashboardASN; country: string; expandedASNs: Set<string>; toggleASN: (key: string) => void; asnDB: Record<string, string> | null; regionToCity?: Map<string, string>; filters: ArmFilters }) {
+function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity, filters, onLiveArmsLoaded }: { asn: DashboardASN; country: string; expandedASNs: Set<string>; toggleASN: (key: string) => void; asnDB: Record<string, string> | null; regionToCity?: Map<string, string>; filters: ArmFilters; onLiveArmsLoaded?: (asn: string, arms: DashboardArmEntry[]) => void }) {
   const key = `${country}-${asn.asn}`;
   const expanded = expandedASNs.has(key);
   const name = asnDisplayName(asn.asn, asnDB);
@@ -470,7 +470,13 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
     setLoadingAll(true);
     setAllArmsErr(null);
     fetchASNArms(asn.asn)
-      .then((resp) => { setAllArms(resp.arms); })
+      .then((resp) => {
+        setAllArms(resp.arms);
+        // Let the parent union these regions/protocols into the filter
+        // dropdowns so low-weight arms that only appear in the live fetch
+        // are still filterable.
+        onLiveArmsLoaded?.(asn.asn, resp.arms);
+      })
       .catch((e) => {
         // Log the raw error for operators inspecting the console; show a
         // short friendly message in the UI so the page doesn't expose
@@ -479,7 +485,7 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
         setAllArmsErr("Unable to load all arms right now. Please try again.");
       })
       .finally(() => { setLoadingAll(false); });
-  }, [asn.asn]);
+  }, [asn.asn, onLiveArmsLoaded]);
 
   const baseArms = allArms ?? asn.topArms;
   const displayedArms = useMemo(() => filterAndSortArms(baseArms, filters), [baseArms, filters]);
@@ -730,6 +736,17 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
   const [expandedASNs, setExpandedASNs] = useState<Set<string>>(new Set());
   const [asnCache, setAsnCache] = useState<Map<string, DashboardASN[]>>(new Map());
   const [loadingCountries, setLoadingCountries] = useState<Set<string>>(new Set());
+  // Full live-arm fetches keyed by ASN. Populated when a user clicks "Show all
+  // arms (live)" inside an ISPSection; the regions/protocols seen here get
+  // merged into the filter dropdown options below.
+  const [liveArmsCache, setLiveArmsCache] = useState<Map<string, DashboardArmEntry[]>>(new Map());
+  const handleLiveArmsLoaded = useCallback((asn: string, arms: DashboardArmEntry[]) => {
+    setLiveArmsCache((prev) => {
+      const next = new Map(prev);
+      next.set(asn, arms);
+      return next;
+    });
+  }, []);
 
   // Arm filter / sort state — applies to every expanded ASN's arm list.
   const [regionFilter, setRegionFilter] = useState<string>("");
@@ -745,20 +762,27 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
   const { availableRegions, availableProtocols } = useMemo(() => {
     const regions = new Set<string>();
     const protocols = new Set<string>();
+    const addArm = (arm: DashboardArmEntry) => {
+      if (arm.regionName) regions.add(arm.regionName);
+      const proto = protocolFromTrackName(arm.trackName);
+      if (proto) protocols.add(proto);
+    };
     for (const asnList of asnCache.values()) {
       for (const asn of asnList) {
-        for (const arm of asn.topArms) {
-          if (arm.regionName) regions.add(arm.regionName);
-          const proto = protocolFromTrackName(arm.trackName);
-          if (proto) protocols.add(proto);
-        }
+        for (const arm of asn.topArms) addArm(arm);
       }
+    }
+    // Also include arms discovered via the live per-ASN fetch so low-weight
+    // regions/protocols that never made the snapshot top-N are still
+    // filterable once a user drills in.
+    for (const arms of liveArmsCache.values()) {
+      for (const arm of arms) addArm(arm);
     }
     return {
       availableRegions: Array.from(regions).sort(),
       availableProtocols: Array.from(protocols).sort(),
     };
-  }, [asnCache]);
+  }, [asnCache, liveArmsCache]);
 
   const sorted = useMemo(
     () => [...countries].sort((a, b) => b.asnCount - a.asnCount),
@@ -1004,6 +1028,7 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
                       asnDB={asnDB}
                       regionToCity={regionToCity}
                       filters={armFilters}
+                      onLiveArmsLoaded={handleLiveArmsLoaded}
                     />
                   ))}
                 </div>

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -379,7 +379,13 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
     setAllArmsErr(null);
     fetchASNArms(asn.asn)
       .then((resp) => { setAllArms(resp.arms); })
-      .catch((e) => { setAllArmsErr(e instanceof Error ? e.message : String(e)); })
+      .catch((e) => {
+        // Log the raw error for operators inspecting the console; show a
+        // short friendly message in the UI so the page doesn't expose
+        // transport-level details.
+        console.error("Failed to load ASN arms", e);
+        setAllArmsErr("Unable to load all arms right now. Please try again.");
+      })
       .finally(() => { setLoadingAll(false); });
   }, [asn.asn]);
 


### PR DESCRIPTION
## Summary

Adds a per-ASN "Show all N arms (live)" button in the Bandit Arms tab that fetches the complete EXP3 arm list directly from Redis via the new \`/dashboard/asn-arms\` endpoint ([getlantern/lantern-cloud#2560](https://github.com/getlantern/lantern-cloud/pull/2560)).

## Why

The Bandit Arms tab shows only the top-N arms from the periodic snapshot (currently top 10). That works for overview but hides slow-but-interesting arms — e.g., the freshly-deployed Reflex routes sitting near the bottom of the EXP3 ranking today. Operators investigating "why is reflex-linode-pro failing in Macau?" couldn't see the arm at all without SQL.

## UX

- **Default**: Unchanged. Each ASN row shows the top-N from the snapshot, collapsed/expanded as before.
- **When expanded**: If the snapshot has fewer arms than \`numArms\`, a subtle "Show all N arms (live)" button appears below.
- **Click**: Fetches from \`/dashboard/asn-arms?asn=<asn>\`, replaces the visible arm list with the full set. Chip updates to "N arms (all shown, live)".
- **Error**: Inline red error message next to the button.

Minimal per-section state: \`allArms\` (null until loaded), \`loadingAll\`, error. On-demand = drilling into 3 ASNs costs 3 Redis reads instead of inflating every snapshot with 100-arm JSON.

## Depends on

- getlantern/lantern-cloud#2560 — server-side \`/dashboard/asn-arms\` endpoint. This PR no-ops without it (button shows, click returns 404).

## Test

- [x] \`npx tsc --noEmit\` clean
- [ ] Visual: expand an ASN, click "Show all arms (live)", verify arms beyond the snapshot top-N appear with weight/region/track metadata
- [ ] Error path: temporarily block the endpoint, click again, verify inline error