### PR TITLE
feat: admin controls for deprecate, pool size, and locations

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -370,3 +370,92 @@ export function getStreamURL(): string {
   if (authToken) url.searchParams.set("token", authToken);
   return url.toString();
 }
+
+// ── Admin mutations ──
+// All endpoints below are OAuth-gated server-side; the actor's email is
+// audit-logged on every call via the otel span the handler creates.
+
+async function apiMutate<T = void>(
+  path: string,
+  method: "POST" | "PATCH" | "PUT",
+  body?: unknown,
+): Promise<T> {
+  const url = `${API_URL}/v1/dashboard${path}`;
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+  if (authToken) headers.Authorization = `Bearer ${authToken}`;
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`${method} ${path}: ${res.status} ${res.statusText}${text ? ` — ${text}` : ""}`);
+  }
+  // Some handlers return no body (204/200 empty). Guard against that.
+  const ct = res.headers.get("content-type") ?? "";
+  if (!ct.includes("application/json")) return undefined as T;
+  return (await res.json()) as T;
+}
+
+/** Deprecate (or un-deprecate) a single route by ID. */
+export function deprecateRoute(routeId: string, undeprecate = false): Promise<void> {
+  return apiMutate<void>(`/routes/${encodeURIComponent(routeId)}/deprecate`, "POST", { undeprecate });
+}
+
+export interface UpdateTrackBody {
+  vpsPoolSize?: number;
+  disabled?: boolean;
+  testing?: boolean;
+}
+
+/** PATCH a small set of safe fields on a track. Omitted fields are left alone. */
+export function updateTrack(trackId: number, body: UpdateTrackBody): Promise<void> {
+  return apiMutate<void>(`/tracks/${trackId}`, "PATCH", body);
+}
+
+export interface UpdateTrackLocationsBody {
+  locationIds: number[];
+  deprecateRemovedRoutes?: boolean;
+}
+
+export interface UpdateTrackLocationsResponse {
+  added: number[];
+  removed: number[];
+  routesDeprecated: number;
+}
+
+/** Replace the full vps_locations set for a track. */
+export function updateTrackLocations(
+  trackId: number,
+  body: UpdateTrackLocationsBody,
+): Promise<UpdateTrackLocationsResponse> {
+  return apiMutate<UpdateTrackLocationsResponse>(`/tracks/${trackId}/locations`, "PUT", body);
+}
+
+export interface DashboardLocation {
+  id: number;
+  name: string;
+  providerName: string;
+}
+
+/** List all locations, optionally scoped by provider name (e.g. "LINODE"). */
+export function fetchLocations(provider?: string): Promise<DashboardLocation[]> {
+  const params: Record<string, string> = {};
+  if (provider) params.provider = provider;
+  return apiFetch<DashboardLocation[]>("/locations", params);
+}
+
+/** Read the current vps_locations for a track (for pre-populating the editor). */
+export function fetchTrackLocations(trackId: number): Promise<{ locationId: number; name: string }[]> {
+  // Reuses the existing unauthed /track-locations/{id} endpoint which is
+  // behind the same API host. It returns [{locationId, name}].
+  return fetch(`${API_URL}/track-locations/${trackId}`, {
+    headers: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
+  })
+    .then((r) => {
+      if (!r.ok) throw new Error(`track-locations ${trackId}: ${r.status}`);
+      return r.json();
+    });
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -221,6 +221,7 @@ export default function Dashboard() {
             summary={vpsData.summary}
             isLoading={vpsData.isLoading}
             error={vpsData.error}
+            onRefresh={vpsData.refresh}
           />
         ) : activeTab === "arms" ? (
           <BanditArmsOverview countries={globalStats.countries} dataCenters={dataCenters} isLive={isLive} />

--- a/src/components/TracksOverview.tsx
+++ b/src/components/TracksOverview.tsx
@@ -1,6 +1,16 @@
 import { useState, useEffect, useMemo, useCallback, useRef, memo, type CSSProperties } from "react";
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
-import { fetchTracks, fetchSigNozMetrics, type DashboardTrackDetail, type TrackMetrics } from "../api/client";
+import {
+  fetchTracks,
+  fetchSigNozMetrics,
+  updateTrack,
+  updateTrackLocations,
+  fetchLocations,
+  fetchTrackLocations,
+  type DashboardTrackDetail,
+  type TrackMetrics,
+  type DashboardLocation,
+} from "../api/client";
 
 const TIER_COLORS: Record<string, string> = {
   FREE: "#a0c8a0",
@@ -263,6 +273,35 @@ const detailLabel: CSSProperties = {
   marginBottom: "0.15rem",
 };
 
+const editButtonStyle: CSSProperties = {
+  all: "unset",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.5rem",
+  color: "#00e5c8",
+  border: "1px solid #00e5c840",
+  padding: "0.1rem 0.35rem",
+  borderRadius: "3px",
+  cursor: "pointer",
+  textTransform: "uppercase",
+  letterSpacing: "0.03em",
+};
+
+function flagButtonStyle(on: boolean, accent: string): CSSProperties {
+  return {
+    all: "unset",
+    fontFamily: "var(--font-mono)",
+    fontSize: "0.52rem",
+    color: on ? accent : "#667080",
+    border: `1px solid ${on ? `${accent}60` : "#ffffff14"}`,
+    background: on ? `${accent}15` : "transparent",
+    padding: "0.15rem 0.45rem",
+    borderRadius: "3px",
+    cursor: "pointer",
+    textTransform: "uppercase",
+    letterSpacing: "0.03em",
+  };
+}
+
 type SortField = "name" | "tier" | "protocol" | "vpsRunning" | "vpsPoolSize";
 type FilterTier = "all" | "Free" | "Pro" | "New";
 type FilterStatus = "all" | "withRoutes" | "empty";
@@ -311,27 +350,68 @@ function TracksOverview() {
   const [metricsTimeRange, setMetricsTimeRange] = useState<"1h" | "6h" | "24h" | "7d">("6h");
   const metricsLoadingRef = useRef(false);
 
+  // ── Edit state ──
+  // Which track (if any) is being edited, and what dialog is active.
+  // The "poolConfirm" dialog shows a 2-step confirm when a pool-size bump
+  // would trigger provisioning. The "locations" dialog is the multi-select
+  // editor. `busy` disables every control while a mutation is in flight.
+  const [poolEdit, setPoolEdit] = useState<{ trackId: number; trackName: string; current: number; next: number } | null>(null);
+  const [savingTrackId, setSavingTrackId] = useState<number | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
+  const [locEditor, setLocEditor] = useState<{ trackId: number; trackName: string; providers: string[] } | null>(null);
+
+  const savePoolSize = async () => {
+    if (!poolEdit) return;
+    setSavingTrackId(poolEdit.trackId);
+    setEditError(null);
+    try {
+      await updateTrack(poolEdit.trackId, { vpsPoolSize: poolEdit.next });
+      setPoolEdit(null);
+      await reloadTracks();
+    } catch (e) {
+      console.error("update pool size failed", e);
+      setEditError(e instanceof Error ? e.message : "Failed to update pool size");
+    } finally {
+      setSavingTrackId(null);
+    }
+  };
+
+  const toggleFlag = async (track: DashboardTrackDetail, field: "disabled" | "testing", value: boolean) => {
+    setSavingTrackId(track.id);
+    setEditError(null);
+    try {
+      await updateTrack(track.id, { [field]: value });
+      await reloadTracks();
+    } catch (e) {
+      console.error(`update ${field} failed`, e);
+      setEditError(e instanceof Error ? e.message : `Failed to update ${field}`);
+    } finally {
+      setSavingTrackId(null);
+    }
+  };
+
+  const reloadTracks = useCallback(async () => {
+    try {
+      const data = await fetchTracks();
+      setTracks(data.tracks || []);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load tracks");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
-    const load = async () => {
-      try {
-        const data = await fetchTracks();
-        if (!cancelled) {
-          setTracks(data.tracks || []);
-          setError(null);
-          setIsLoading(false);
-        }
-      } catch (e) {
-        if (!cancelled) {
-          setError(e instanceof Error ? e.message : "Failed to load tracks");
-          setIsLoading(false);
-        }
-      }
+    const tick = async () => {
+      if (cancelled) return;
+      await reloadTracks();
     };
-    load();
-    const interval = setInterval(load, 60_000);
+    tick();
+    const interval = setInterval(tick, 60_000);
     return () => { cancelled = true; clearInterval(interval); };
-  }, []);
+  }, [reloadTracks]);
 
   // Fetch SigNoz metrics grouped by track
   useEffect(() => {
@@ -518,6 +598,36 @@ function TracksOverview() {
   }
 
   return (
+    <>
+    {editError && (
+      <div style={{
+        position: "fixed", top: "1rem", right: "1rem", zIndex: 9001,
+        background: "#e06060", color: "#fff",
+        fontFamily: "var(--font-mono)", fontSize: "0.65rem",
+        padding: "0.5rem 0.9rem", borderRadius: "4px",
+        boxShadow: "0 4px 12px rgba(0,0,0,0.4)",
+        maxWidth: "360px",
+      }}>
+        {editError}
+      </div>
+    )}
+    {poolEdit && <PoolSizeConfirm
+      edit={poolEdit}
+      busy={savingTrackId !== null}
+      onCancel={() => setPoolEdit(null)}
+      onSave={savePoolSize}
+      onChange={(next) => setPoolEdit({ ...poolEdit, next })}
+    />}
+    {locEditor && <LocationsEditor
+      trackId={locEditor.trackId}
+      trackName={locEditor.trackName}
+      providers={locEditor.providers}
+      busy={savingTrackId !== null}
+      onClose={() => setLocEditor(null)}
+      onSaved={async () => { setLocEditor(null); await reloadTracks(); }}
+      setBusyId={setSavingTrackId}
+      setErr={setEditError}
+    />}
     <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.75rem", overflowY: "auto", padding: "0.75rem" }}>
       {/* Summary Cards */}
       <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
@@ -810,11 +920,63 @@ function TracksOverview() {
                     <>
                       <div>
                         <div style={detailLabel}>Pool Size</div>
-                        <div>{track.vpsPoolSize} per location</div>
+                        <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                          <span>{track.vpsPoolSize} per location</span>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setEditError(null);
+                              setPoolEdit({ trackId: track.id, trackName: track.name, current: track.vpsPoolSize, next: track.vpsPoolSize });
+                            }}
+                            disabled={savingTrackId === track.id}
+                            style={editButtonStyle}
+                          >
+                            edit
+                          </button>
+                        </div>
                       </div>
                       <div>
                         <div style={detailLabel}>Route Age</div>
                         <div>{track.routeAgeHours ? `${track.routeAgeHours}h` : "never expires"}</div>
+                      </div>
+                      <div>
+                        <div style={detailLabel}>Locations</div>
+                        <div>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setEditError(null);
+                              setLocEditor({ trackId: track.id, trackName: track.name, providers: track.providers });
+                            }}
+                            disabled={savingTrackId === track.id}
+                            style={editButtonStyle}
+                          >
+                            edit locations
+                          </button>
+                        </div>
+                      </div>
+                      <div>
+                        <div style={detailLabel}>Flags</div>
+                        <div style={{ display: "flex", gap: "0.4rem", flexWrap: "wrap" }}>
+                          <button
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); toggleFlag(track, "disabled", !track.disabled); }}
+                            disabled={savingTrackId === track.id}
+                            style={flagButtonStyle(track.disabled, "#e06060")}
+                          >
+                            {track.disabled ? "disabled ✓" : "disabled"}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); toggleFlag(track, "testing", !track.testing); }}
+                            disabled={savingTrackId === track.id}
+                            style={flagButtonStyle(track.testing, "#f0a030")}
+                          >
+                            {track.testing ? "testing ✓" : "testing"}
+                          </button>
+                        </div>
                       </div>
                     </>
                   )}
@@ -903,6 +1065,277 @@ function TracksOverview() {
             No tracks match filters
           </div>
         )}
+      </div>
+    </div>
+    </>
+  );
+}
+
+// ── Pool-size confirmation dialog ──
+// Two-step intent: shows the current size, lets the user type the new size,
+// and spells out the consequence ("increasing triggers immediate VPS
+// provisioning by the pool worker on its next cycle"). Save is disabled until
+// the value actually changes.
+function PoolSizeConfirm({
+  edit,
+  busy,
+  onCancel,
+  onSave,
+  onChange,
+}: {
+  edit: { trackId: number; trackName: string; current: number; next: number };
+  busy: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+  onChange: (n: number) => void;
+}) {
+  const diff = edit.next - edit.current;
+  const willTriggerProvisioning = diff > 0;
+  const willTriggerDeprecation = diff < 0;
+  return (
+    <div
+      onClick={() => !busy && onCancel()}
+      style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9000 }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ background: "var(--bg-card)", border: "1px solid #00e5c840", borderRadius: "6px", padding: "1.1rem 1.3rem", width: "min(480px, 92vw)", fontFamily: "var(--font-sans)", color: "#c0c8d4", boxShadow: "0 10px 40px rgba(0,0,0,0.6)" }}
+      >
+        <div style={{ fontSize: "0.8rem", fontWeight: 600, color: "#00e5c8", marginBottom: "0.5rem" }}>
+          Edit pool size — {edit.trackName}
+        </div>
+        <div style={{ fontSize: "0.72rem", lineHeight: 1.6, color: "#a0a8b8" }}>
+          Current pool size: <strong>{edit.current}</strong> VPS routes per location.
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginTop: "0.8rem" }}>
+          <span style={{ fontSize: "0.7rem", color: "#8890a0" }}>New size:</span>
+          <input
+            type="number"
+            min={0}
+            max={50}
+            value={edit.next}
+            onChange={(e) => onChange(Math.max(0, Math.min(50, parseInt(e.target.value) || 0)))}
+            disabled={busy}
+            style={{ all: "unset", fontFamily: "var(--font-mono)", fontSize: "0.9rem", color: "#00e5c8", background: "#00e5c808", border: "1px solid #00e5c830", padding: "0.25rem 0.5rem", borderRadius: "4px", width: "4rem", textAlign: "center" }}
+          />
+          <span style={{ fontSize: "0.7rem", color: "#667080" }}>per location</span>
+        </div>
+        <div style={{ marginTop: "0.9rem", fontSize: "0.68rem", lineHeight: 1.55, padding: "0.6rem 0.75rem", borderRadius: "4px", background: willTriggerProvisioning ? "#f0a03012" : willTriggerDeprecation ? "#e0606012" : "#ffffff05", color: willTriggerProvisioning ? "#f0a030" : willTriggerDeprecation ? "#e06060" : "#8890a0", border: `1px solid ${willTriggerProvisioning ? "#f0a03030" : willTriggerDeprecation ? "#e0606030" : "#ffffff0a"}` }}>
+          {willTriggerProvisioning ? (
+            <>Heads up: increasing pool size triggers <strong>new VPS provisioning</strong> on the next pool-worker tick (~60s). This will incur cloud-provider costs.</>
+          ) : willTriggerDeprecation ? (
+            <>Heads up: decreasing pool size will cause the pool worker to <strong>deprecate excess routes</strong> (up to {Math.abs(diff)} per location), triggering VM teardown.</>
+          ) : (
+            <>No change from current value.</>
+          )}
+        </div>
+        <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem", justifyContent: "flex-end" }}>
+          <button type="button" onClick={onCancel} disabled={busy} style={{ all: "unset", fontFamily: "var(--font-mono)", fontSize: "0.68rem", padding: "0.35rem 0.8rem", borderRadius: "4px", cursor: busy ? "not-allowed" : "pointer", color: "#8890a0" }}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={busy || diff === 0}
+            style={{ all: "unset", fontFamily: "var(--font-mono)", fontSize: "0.68rem", padding: "0.35rem 0.9rem", borderRadius: "4px", background: diff === 0 ? "#667080" : "#00e5c8", color: "#0a0f14", cursor: (busy || diff === 0) ? "not-allowed" : "pointer", fontWeight: 600, opacity: diff === 0 ? 0.5 : 1 }}
+          >
+            {busy ? "Saving…" : `Apply (${edit.current} → ${edit.next})`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Locations editor ──
+// Multi-select of locations filtered to the track's providers. Shows current
+// set as removable chips and a dropdown of available-but-unselected locations.
+// Removing a location prompts the operator to also deprecate any vps_routes
+// in that location — critical because the track's pool worker would otherwise
+// orphan them (see 2026-04-13 Madrid incident).
+function LocationsEditor({
+  trackId,
+  trackName,
+  providers,
+  busy,
+  onClose,
+  onSaved,
+  setBusyId,
+  setErr,
+}: {
+  trackId: number;
+  trackName: string;
+  providers: string[];
+  busy: boolean;
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+  setBusyId: (id: number | null) => void;
+  setErr: (msg: string | null) => void;
+}) {
+  const [current, setCurrent] = useState<{ locationId: number; name: string }[] | null>(null);
+  const [available, setAvailable] = useState<DashboardLocation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deprecateRemoved, setDeprecateRemoved] = useState(true);
+  const [addPickerOpen, setAddPickerOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // We load locations for every provider the track supports and union
+        // them so a track on ["LINODE", "OCI"] sees both provider's locations.
+        const [cur, ...provLists] = await Promise.all([
+          fetchTrackLocations(trackId),
+          ...providers.map((p) => fetchLocations(p)),
+        ]);
+        if (cancelled) return;
+        setCurrent(cur);
+        const merged = new Map<number, DashboardLocation>();
+        for (const list of provLists) {
+          for (const l of list) merged.set(l.id, l);
+        }
+        setAvailable(Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name)));
+      } catch (e) {
+        console.error("load locations for editor failed", e);
+        if (!cancelled) setErr(e instanceof Error ? e.message : "Failed to load locations");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [trackId, providers, setErr]);
+
+  const selectedIds = new Set((current ?? []).map((c) => c.locationId));
+  const pickableLocations = available.filter((l) => !selectedIds.has(l.id));
+
+  const remove = (id: number) => {
+    setCurrent((prev) => prev ? prev.filter((c) => c.locationId !== id) : prev);
+  };
+  const add = (loc: DashboardLocation) => {
+    setCurrent((prev) => prev ? [...prev, { locationId: loc.id, name: loc.name }].sort((a, b) => a.name.localeCompare(b.name)) : [{ locationId: loc.id, name: loc.name }]);
+    setAddPickerOpen(false);
+  };
+
+  const save = async () => {
+    if (!current) return;
+    setBusyId(trackId);
+    setErr(null);
+    try {
+      const resp = await updateTrackLocations(trackId, {
+        locationIds: current.map((c) => c.locationId),
+        deprecateRemovedRoutes: deprecateRemoved,
+      });
+      if (resp.routesDeprecated > 0) {
+        // Surface the side-effect so the operator sees it.
+        setErr(null);
+      }
+      await onSaved();
+    } catch (e) {
+      console.error("save track locations failed", e);
+      setErr(e instanceof Error ? e.message : "Failed to save locations");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div
+      onClick={() => !busy && onClose()}
+      style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9000 }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ background: "var(--bg-card)", border: "1px solid #00e5c840", borderRadius: "6px", padding: "1.1rem 1.3rem", width: "min(620px, 94vw)", maxHeight: "85vh", display: "flex", flexDirection: "column", fontFamily: "var(--font-sans)", color: "#c0c8d4", boxShadow: "0 10px 40px rgba(0,0,0,0.6)" }}
+      >
+        <div style={{ fontSize: "0.8rem", fontWeight: 600, color: "#00e5c8", marginBottom: "0.3rem" }}>
+          Edit locations — {trackName}
+        </div>
+        <div style={{ fontSize: "0.65rem", color: "#667080" }}>
+          Providers: {providers.join(", ")}
+        </div>
+
+        <div style={{ marginTop: "0.9rem", flex: 1, overflowY: "auto" }}>
+          {loading ? (
+            <div style={{ color: "#667080", fontFamily: "var(--font-mono)", fontSize: "0.7rem" }}>Loading locations…</div>
+          ) : (
+            <>
+              <div style={{ fontSize: "0.62rem", color: "#8890a0", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.4rem" }}>
+                Current ({current?.length ?? 0})
+              </div>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "0.35rem" }}>
+                {(current ?? []).map((c) => (
+                  <span key={c.locationId} style={{ display: "inline-flex", alignItems: "center", gap: "0.25rem", background: "#00e5c810", color: "#00e5c8", border: "1px solid #00e5c830", padding: "0.15rem 0.45rem", borderRadius: "3px", fontFamily: "var(--font-mono)", fontSize: "0.62rem" }}>
+                    {c.name}
+                    <button
+                      type="button"
+                      onClick={() => remove(c.locationId)}
+                      disabled={busy}
+                      style={{ all: "unset", cursor: busy ? "not-allowed" : "pointer", color: "#00e5c8", opacity: 0.7, fontSize: "0.7rem" }}
+                      title={`Remove ${c.name}`}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => setAddPickerOpen((v) => !v)}
+                  disabled={busy || pickableLocations.length === 0}
+                  style={{ all: "unset", cursor: busy ? "not-allowed" : "pointer", fontFamily: "var(--font-mono)", fontSize: "0.62rem", color: "#a0a8b8", border: "1px dashed #ffffff20", padding: "0.15rem 0.45rem", borderRadius: "3px" }}
+                >
+                  {addPickerOpen ? "– close" : "+ add"}
+                </button>
+              </div>
+
+              {addPickerOpen && (
+                <div style={{ marginTop: "0.6rem", border: "1px solid #ffffff0a", borderRadius: "4px", maxHeight: "220px", overflowY: "auto" }}>
+                  {pickableLocations.map((loc) => (
+                    <button
+                      key={loc.id}
+                      type="button"
+                      onClick={() => add(loc)}
+                      style={{ all: "unset", display: "flex", justifyContent: "space-between", width: "100%", padding: "0.35rem 0.6rem", fontFamily: "var(--font-mono)", fontSize: "0.62rem", color: "#c0c8d4", cursor: "pointer", borderBottom: "1px solid #ffffff06" }}
+                      onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "#00e5c808"; }}
+                      onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "transparent"; }}
+                    >
+                      <span>{loc.name}</span>
+                      <span style={{ color: "#667080" }}>{loc.providerName}</span>
+                    </button>
+                  ))}
+                  {pickableLocations.length === 0 && (
+                    <div style={{ padding: "0.6rem", color: "#667080", fontSize: "0.62rem", textAlign: "center" }}>
+                      No more locations available for this track's providers.
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginTop: "1rem", fontSize: "0.68rem", color: "#a0a8b8", cursor: "pointer" }}>
+                <input type="checkbox" checked={deprecateRemoved} onChange={(e) => setDeprecateRemoved(e.target.checked)} disabled={busy} />
+                <span>
+                  Also deprecate existing VPS routes in removed locations
+                  <div style={{ fontSize: "0.58rem", color: "#667080", marginTop: "0.1rem" }}>
+                    Recommended — prevents orphaned routes (see the 2026-04-13 Madrid incident).
+                  </div>
+                </span>
+              </label>
+            </>
+          )}
+        </div>
+
+        <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem", justifyContent: "flex-end" }}>
+          <button type="button" onClick={onClose} disabled={busy} style={{ all: "unset", fontFamily: "var(--font-mono)", fontSize: "0.68rem", padding: "0.35rem 0.8rem", borderRadius: "4px", cursor: busy ? "not-allowed" : "pointer", color: "#8890a0" }}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={busy || loading || !current}
+            style={{ all: "unset", fontFamily: "var(--font-mono)", fontSize: "0.68rem", padding: "0.35rem 0.9rem", borderRadius: "4px", background: "#00e5c8", color: "#0a0f14", cursor: busy ? "wait" : "pointer", fontWeight: 600 }}
+          >
+            {busy ? "Saving…" : "Save locations"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/VPSOverview.tsx
+++ b/src/components/VPSOverview.tsx
@@ -1,11 +1,25 @@
 import { useState, useMemo, useEffect, memo, type CSSProperties } from "react";
-import type { DashboardVPSRoute, DashboardVPSSummary } from "../api/client";
+import { deprecateRoute, type DashboardVPSRoute, type DashboardVPSSummary } from "../api/client";
 
 interface VPSOverviewProps {
   routes: DashboardVPSRoute[];
   summary: DashboardVPSSummary | null;
   isLoading: boolean;
   error: string | null;
+  onRefresh?: () => void;
+}
+
+// Routes in provisioning/configuring that have been around for >10 min are
+// effectively stuck — the pool worker retries every ~60s so anything that
+// hasn't reached "running" by then almost certainly won't without intervention.
+const STUCK_THRESHOLD_MS = 10 * 60 * 1000;
+
+function isStuck(route: DashboardVPSRoute): boolean {
+  if (route.deprecated) return false;
+  if (route.status !== "provisioning" && route.status !== "configuring" && route.status !== "pending") {
+    return false;
+  }
+  return Date.now() - Date.parse(route.created) > STUCK_THRESHOLD_MS;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -133,10 +147,33 @@ const badgeBase: CSSProperties = {
   whiteSpace: "nowrap",
 };
 
-function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
+function VPSOverview({ routes, summary, isLoading, error, onRefresh }: VPSOverviewProps) {
   const [collapsedRegions, setCollapsedRegions] = useState<Set<string>>(new Set());
   const [copiedRouteId, setCopiedRouteId] = useState<string | null>(null);
   const [, setTick] = useState(0);
+
+  // Deprecation state: one pending route id while a request is in-flight, plus
+  // a confirmation modal payload for the row the user has armed.
+  const [confirmDeprecate, setConfirmDeprecate] = useState<DashboardVPSRoute | null>(null);
+  const [deprecatingId, setDeprecatingId] = useState<string | null>(null);
+  const [deprecateError, setDeprecateError] = useState<string | null>(null);
+
+  const runDeprecate = async (route: DashboardVPSRoute) => {
+    setDeprecatingId(route.id);
+    setDeprecateError(null);
+    try {
+      await deprecateRoute(route.id);
+      setConfirmDeprecate(null);
+      onRefresh?.();
+    } catch (err) {
+      console.error("deprecate route failed", err);
+      setDeprecateError(
+        err instanceof Error ? err.message : "Failed to deprecate route",
+      );
+    } finally {
+      setDeprecatingId(null);
+    }
+  };
 
   useEffect(() => {
     const id = setInterval(() => setTick((t) => t + 1), 60_000);
@@ -237,6 +274,7 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
   }
 
   return (
+    <>
     <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.75rem", overflowY: "auto", padding: "0.75rem" }}>
       {/* Summary Cards */}
       <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
@@ -380,8 +418,8 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
                           <span style={{ color: "#667080" }}> / {route.peakAssignmentCount}</span>
                         </span>
 
-                        {/* Status / Deprecated badge */}
-                        <span>
+                        {/* Status / Deprecated badge + stuck indicator */}
+                        <span style={{ display: "inline-flex", gap: "4px", alignItems: "center" }}>
                           {isDeprecated ? (
                             <span style={{ ...badgeBase, background: "#e0606018", color: "#e06060", border: "1px solid #e0606030" }}>
                               deprecated
@@ -391,7 +429,45 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
                               {route.status}
                             </span>
                           )}
+                          {isStuck(route) && (
+                            <span
+                              title={`In ${route.status} for > ${Math.floor((Date.now() - Date.parse(route.created)) / 60000)} minutes — likely stuck`}
+                              style={{ ...badgeBase, background: "#e0606010", color: "#e06060", border: "1px dashed #e0606050" }}
+                            >
+                              stuck
+                            </span>
+                          )}
                         </span>
+
+                        {/* Deprecate button */}
+                        {!isDeprecated && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeprecateError(null);
+                              setConfirmDeprecate(route);
+                            }}
+                            disabled={deprecatingId === route.id}
+                            title="Deprecate this route (pool worker will destroy the VM)"
+                            style={{
+                              all: "unset",
+                              fontFamily: "var(--font-mono)",
+                              fontSize: "0.52rem",
+                              color: "#e06060",
+                              border: "1px solid #e0606040",
+                              background: "#e0606008",
+                              padding: "0.1rem 0.4rem",
+                              borderRadius: "3px",
+                              textTransform: "uppercase",
+                              letterSpacing: "0.03em",
+                              cursor: deprecatingId === route.id ? "wait" : "pointer",
+                              opacity: deprecatingId === route.id ? 0.5 : 1,
+                            }}
+                          >
+                            {deprecatingId === route.id ? "…" : "Deprecate"}
+                          </button>
+                        )}
 
                         {/* SSH command — copy to clipboard */}
                         <button
@@ -435,6 +511,84 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
         })}
       </div>
     </div>
+    {confirmDeprecate && (
+      <div
+        onClick={() => !deprecatingId && setConfirmDeprecate(null)}
+        style={{
+          position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)",
+          display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9000,
+        }}
+      >
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: "var(--bg-card)",
+            border: "1px solid #e0606040",
+            borderRadius: "6px",
+            padding: "1.1rem 1.3rem",
+            width: "min(460px, 92vw)",
+            fontFamily: "var(--font-sans)",
+            color: "#c0c8d4",
+            boxShadow: "0 10px 40px rgba(0,0,0,0.6)",
+          }}
+        >
+          <div style={{ fontSize: "0.8rem", fontWeight: 600, color: "#e06060", marginBottom: "0.5rem" }}>
+            Deprecate route?
+          </div>
+          <div style={{ fontSize: "0.72rem", lineHeight: 1.6, color: "#a0a8b8" }}>
+            Route <code style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem" }}>
+              {confirmDeprecate.id.substring(0, 8)}
+            </code> on{" "}
+            <strong>{confirmDeprecate.trackName}</strong> in{" "}
+            <strong>{confirmDeprecate.regionName}</strong>{" "}
+            ({confirmDeprecate.vpsProvider} / {confirmDeprecate.vpsRegion}).
+            The destroy worker will tear down the VM on its next cycle.
+          </div>
+          {deprecateError && (
+            <div style={{ marginTop: "0.75rem", fontSize: "0.68rem", color: "#e06060" }}>
+              {deprecateError}
+            </div>
+          )}
+          <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem", justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              onClick={() => setConfirmDeprecate(null)}
+              disabled={!!deprecatingId}
+              style={{
+                all: "unset",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.68rem",
+                padding: "0.35rem 0.8rem",
+                borderRadius: "4px",
+                cursor: deprecatingId ? "not-allowed" : "pointer",
+                color: "#8890a0",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => runDeprecate(confirmDeprecate)}
+              disabled={!!deprecatingId}
+              style={{
+                all: "unset",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.68rem",
+                padding: "0.35rem 0.9rem",
+                borderRadius: "4px",
+                background: "#e06060",
+                color: "#fff",
+                cursor: deprecatingId ? "wait" : "pointer",
+                fontWeight: 600,
+              }}
+            >
+              {deprecatingId === confirmDeprecate.id ? "Deprecating…" : "Deprecate"}
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
+    </>
   );
 }
 

--- a/src/hooks/useVPSData.ts
+++ b/src/hooks/useVPSData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { fetchInfrastructure, type DashboardVPSRoute, type DashboardVPSSummary } from "../api/client";
 import { useAuth } from "./useAuth";
 
@@ -8,12 +8,15 @@ export function useVPSData(enabled: boolean) {
   const [summary, setSummary] = useState<DashboardVPSSummary | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
 
   useEffect(() => {
     if (!enabled || !isAuthenticated) return;
     let cancelled = false;
 
-    const refresh = async () => {
+    const load = async () => {
       setIsLoading(true);
       try {
         const data = await fetchInfrastructure(true);
@@ -34,10 +37,10 @@ export function useVPSData(enabled: boolean) {
       }
     };
 
-    refresh();
-    const interval = setInterval(refresh, 60000);
+    load();
+    const interval = setInterval(load, 60000);
     return () => { cancelled = true; clearInterval(interval); };
-  }, [enabled, isAuthenticated]);
+  }, [enabled, isAuthenticated, refreshKey]);
 
-  return { routes, summary, isLoading, error };
+  return { routes, summary, isLoading, error, refresh };
 }


### PR DESCRIPTION
## Summary

Adds operator-facing mutations to the dashboard so routine recovery doesn't require dropping into the \`lc\` CLI. Companion PR: getlantern/lantern-cloud#2561.

### Infrastructure tab
- Per-row **Deprecate** button with a confirmation modal that explains the consequence (destroy worker tears down the VM).
- **stuck** dashed badge on rows stuck in \`provisioning\` / \`configuring\` / \`pending\` for >10 min — these are the rows the button is most useful on.

### Tracks tab
- **Pool-size inline editor** with a two-step confirm dialog that spells out whether the change will trigger provisioning or deprecation and by how much — pool-size bumps create real cloud VMs.
- **disabled / testing toggles** inline.
- **Locations editor**: chips for current vps_locations with an \`+ add\` dropdown scoped to the track's providers. Removing a location defaults to **also deprecating existing vps_routes in that location** (checkbox pre-checked) — this is the right default per the 2026-04-13 Madrid incident where removing a location left orphaned routes behind.

All mutations hit the OAuth-gated \`/v1/dashboard\` endpoints on the server (getlantern/lantern-cloud#2561). Errors surface in a floating banner rather than console-only.

## Test plan

- [ ] Log in, deprecate a stuck \`provisioning\` route in the VPS tab, verify it disappears from Infrastructure within ~30s
- [ ] Increase a track's pool size by 1, confirm the dialog warns about provisioning, verify the pool worker provisions a new route per location within ~60s
- [ ] Remove a location from a track with \`deprecate existing routes\` checked, verify those routes flip to deprecated immediately and the destroy worker cleans them up
- [ ] Toggle \`testing\` on a track, verify the badge updates after reload
- [ ] Cancel each modal and confirm no mutation fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)