### PR TITLE
feat(arms): highlight troubled ISPs in dropdown

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -49,6 +49,9 @@ export interface DashboardCountry {
   asnCount: number;
   avgBlockRate: number;
   avgEntropy: number;
+  avgErrorRate?: number;
+  totalSuccess: number;
+  totalTests: number;
 }
 
 export interface DashboardGlobalStats {
@@ -83,6 +86,9 @@ export interface DashboardASN {
   entropy: number;
   snapshotTime: string;
   topArms: DashboardArmEntry[];
+  totalSuccess: number;
+  totalTests: number;
+  errorRate: number;
 }
 
 export interface DashboardTrackInfo {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -50,8 +50,8 @@ export interface DashboardCountry {
   avgBlockRate: number;
   avgEntropy: number;
   avgErrorRate?: number;
-  totalSuccess: number;
-  totalTests: number;
+  totalSuccess?: number;
+  totalTests?: number;
 }
 
 export interface DashboardGlobalStats {
@@ -86,9 +86,9 @@ export interface DashboardASN {
   entropy: number;
   snapshotTime: string;
   topArms: DashboardArmEntry[];
-  totalSuccess: number;
-  totalTests: number;
-  errorRate: number;
+  totalSuccess?: number;
+  totalTests?: number;
+  errorRate?: number;
 }
 
 export interface DashboardTrackInfo {

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -79,6 +79,8 @@ const CENSORED_COUNTRIES = new Set([
   "KZ", "MM", "PK", "RU", "SA", "TH", "TM", "TR", "UZ", "VE", "VN",
 ]);
 
+const PRIMARY_COUNTRIES = new Set(["CN", "IR", "RU"]);
+
 const ASN_NAMES: Record<string, string> = {
   // Iran
   AS44244: "Irancell", AS197207: "MCI", AS58224: "TCI", AS12880: "Afranet",
@@ -137,6 +139,21 @@ function blockRateColor(rate: number): string {
   if (rate > 0.3) return "#e0a080";
   if (rate > 0.1) return "#d8c090";
   return "#a0c8a0";
+}
+
+function errorRateColor(rate: number): string {
+  if (rate > 0.5) return "#e06060";
+  if (rate > 0.2) return "#e0a080";
+  if (rate > 0.05) return "#d8c090";
+  return "#80c8a0";
+}
+
+function countryHealthColor(c: DashboardCountry): string {
+  const errorRate = c.avgErrorRate ?? 0;
+  if (c.avgBlockRate > 0.3 || errorRate > 0.5) return "#e06060";
+  if (c.avgBlockRate > 0.1 || errorRate > 0.2) return "#e0a080";
+  if (errorRate > 0.05) return "#d8c090";
+  return "#00e5c8";
 }
 
 function successRateColor(rate: number): string {
@@ -748,6 +765,8 @@ function CountryRow({
   const loading = loadingCountries.has(c.country);
   const asns = asnCache.get(c.country);
   const brColor = blockRateColor(c.avgBlockRate);
+  const erColor = c.avgErrorRate != null ? errorRateColor(c.avgErrorRate) : "#556070";
+  const nameColor = countryHealthColor(c);
 
   return (
     <div>
@@ -758,19 +777,30 @@ function CountryRow({
         onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.015)"; }}
       >
         <span style={chevronStyle(expanded)}>&#9662;</span>
-        <span style={{ fontFamily: "var(--font-sans)", fontSize: "0.85rem", fontWeight: 700, color: "#00e5c8" }}>
+        <span style={{ fontFamily: "var(--font-sans)", fontSize: "0.85rem", fontWeight: 700, color: nameColor }}>
           {countryName(c.country)}
         </span>
         <span style={chipStyle}>{asns ? asns.length : c.asnCount} ASN{(asns ? asns.length : c.asnCount) !== 1 ? "s" : ""}</span>
 
-        <Tip text={`${(c.avgBlockRate * 100).toFixed(1)}% of arms are currently blocked for ISPs in ${countryName(c.country)}.`}>
-          <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "90px" }}>
+        <Tip text={`${(c.avgBlockRate * 100).toFixed(1)}% of arms are blocked in ${countryName(c.country)}.`}>
+          <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px" }}>
             <MiniBar value={c.avgBlockRate} color={brColor} />
-            <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.7rem", color: brColor, minWidth: "36px", textAlign: "right" }}>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: brColor, minWidth: "32px", textAlign: "right" }}>
               {c.avgBlockRate < 0.01 ? (c.avgBlockRate * 100).toFixed(2) : (c.avgBlockRate * 100).toFixed(1)}%
             </span>
           </div>
         </Tip>
+
+        {c.avgErrorRate != null && (
+          <Tip text={`${(c.avgErrorRate * 100).toFixed(1)}% of probes fail in ${countryName(c.country)}. Unlike block rate (binary per arm), error rate shows continuous connection quality.`}>
+            <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px" }}>
+              <MiniBar value={c.avgErrorRate} color={erColor} />
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: erColor, minWidth: "32px", textAlign: "right" }}>
+                {(c.avgErrorRate * 100).toFixed(1)}%
+              </span>
+            </div>
+          </Tip>
+        )}
 
         <Tip text={`Weight entropy: ${c.avgEntropy.toFixed(3)}. ${c.avgEntropy < 0.5 ? "Strongly converged." : c.avgEntropy < 1.5 ? "Moderate focus." : "High exploration."}`}>
           <span style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: "0.7rem", color: "#8890a0" }}>
@@ -876,20 +906,24 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
     };
   }, [asnCache, liveArmsCache]);
 
-  const { censoredCountries, uncensoredCountries } = useMemo(() => {
-    const censored: DashboardCountry[] = [];
+  const { primaryCountries, otherCensoredCountries, uncensoredCountries } = useMemo(() => {
+    const primary: DashboardCountry[] = [];
+    const otherCensored: DashboardCountry[] = [];
     const uncensored: DashboardCountry[] = [];
     for (const c of countries) {
-      if (CENSORED_COUNTRIES.has(c.country)) censored.push(c);
+      if (PRIMARY_COUNTRIES.has(c.country)) primary.push(c);
+      else if (CENSORED_COUNTRIES.has(c.country)) otherCensored.push(c);
       else uncensored.push(c);
     }
     const alpha = (a: DashboardCountry, b: DashboardCountry) =>
       countryName(a.country).localeCompare(countryName(b.country));
-    censored.sort(alpha);
+    primary.sort(alpha);
+    otherCensored.sort(alpha);
     uncensored.sort(alpha);
-    return { censoredCountries: censored, uncensoredCountries: uncensored };
+    return { primaryCountries: primary, otherCensoredCountries: otherCensored, uncensoredCountries: uncensored };
   }, [countries]);
 
+  const [showOtherCensored, setShowOtherCensored] = useState(false);
   const [showUncensored, setShowUncensored] = useState(false);
 
   const totalASNs = useMemo(() => {
@@ -911,6 +945,13 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
     const totalWeight = countries.reduce((s, c) => s + c.asnCount, 0);
     if (totalWeight === 0) return 0;
     return countries.reduce((s, c) => s + c.avgEntropy * c.asnCount, 0) / totalWeight;
+  }, [countries]);
+
+  const weightedErrorRate = useMemo(() => {
+    const totalTests = countries.reduce((s, c) => s + (c.totalTests ?? 0), 0);
+    if (totalTests === 0) return 0;
+    const totalSuccess = countries.reduce((s, c) => s + (c.totalSuccess ?? 0), 0);
+    return 1 - totalSuccess / totalTests;
   }, [countries]);
 
   // Fetch ASN data for all countries and refresh every 30s
@@ -999,6 +1040,15 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
             <div style={cardHint}>of arms blocked across all ISPs</div>
           </div>
         </Tip>
+        <Tip text="Percentage of probe callbacks that fail. Unlike block rate (binary: an arm is either blocked or not), error rate shows continuous connection quality. A country may have 0% block rate but 30% error rate — meaning connections are degraded but no arms have crossed the blocking threshold.">
+          <div style={card}>
+            <div style={cardLabel}>Avg Error Rate <InfoIcon /></div>
+            <div style={{ ...cardValue, color: errorRateColor(weightedErrorRate) }}>
+              {(weightedErrorRate * 100).toFixed(1)}%
+            </div>
+            <div style={cardHint}>probe callback failures</div>
+          </div>
+        </Tip>
         <Tip text={`Shannon entropy measures how spread out the bandit's weight distribution is across arms. Low entropy (near 0) means the algorithm has converged on one or two winning arms. High entropy (near ${Math.log2(Math.max(2, totalASNs)).toFixed(1)}) means it's still exploring equally across all options. Moderate values indicate a healthy balance between exploiting known-good arms and exploring alternatives.`}>
           <div style={card}>
             <div style={cardLabel}>Avg Entropy <InfoIcon /></div>
@@ -1066,14 +1116,43 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
         )}
       </div>
 
-      {/* Country list */}
+      {/* Country list — 3 tiers */}
       <div style={{ background: "var(--bg-card)", borderRadius: "var(--radius-md)", border: "1px solid #ffffff08", overflow: "auto", flex: 1 }}>
-        {censoredCountries.map((c) => (
+        {/* Tier 1: China, Iran, Russia — always visible */}
+        {primaryCountries.map((c) => (
           <CountryRow key={c.country} c={c} expandedCountries={expandedCountries} loadingCountries={loadingCountries}
             asnCache={asnCache} toggleCountry={toggleCountry} expandedASNs={expandedASNs} toggleASN={toggleASN}
             asnDB={asnDB} regionToCity={regionToCity} armFilters={armFilters} handleLiveArmsLoaded={handleLiveArmsLoaded} />
         ))}
 
+        {/* Tier 2: Other censored countries — collapsible */}
+        {otherCensoredCountries.length > 0 && (
+          <>
+            <div
+              onClick={() => setShowOtherCensored((v) => !v)}
+              style={{
+                display: "flex", alignItems: "center", gap: "0.5rem",
+                padding: "0.5rem 0.75rem", cursor: "pointer", userSelect: "none",
+                borderTop: "1px solid #ffffff08", borderBottom: showOtherCensored ? "1px solid #ffffff08" : "none",
+                background: "rgba(255,255,255,0.01)",
+              }}
+              onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.03)"; }}
+              onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.01)"; }}
+            >
+              <span style={chevronStyle(showOtherCensored)}>&#9662;</span>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.7rem", color: "#8090a0", letterSpacing: "0.03em" }}>
+                Other censored countries ({otherCensoredCountries.length})
+              </span>
+            </div>
+            {showOtherCensored && otherCensoredCountries.map((c) => (
+              <CountryRow key={c.country} c={c} expandedCountries={expandedCountries} loadingCountries={loadingCountries}
+                asnCache={asnCache} toggleCountry={toggleCountry} expandedASNs={expandedASNs} toggleASN={toggleASN}
+                asnDB={asnDB} regionToCity={regionToCity} armFilters={armFilters} handleLiveArmsLoaded={handleLiveArmsLoaded} />
+            ))}
+          </>
+        )}
+
+        {/* Tier 3: Uncensored countries — collapsible */}
         {uncensoredCountries.length > 0 && (
           <>
             <div

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -481,10 +481,14 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
   const name = asnDisplayName(asn.asn, asnDB);
   const blockedColor = asn.numBlocked > 0 ? "#e06060" : "#667080";
 
-  // Severity is derived from error rate (primary signal) and block rate as a
-  // secondary amplifier. High error rate without blocks = degraded but not
-  // censored; high block rate = active censorship. Either warrants a visible
-  // warning. Requires ≥20 probe tests to avoid noise from low-traffic ASNs.
+  // Severity combines two independent signals:
+  //   • Error rate: from Redis ASN signals (1-hour window). Requires ≥20
+  //     probe tests to avoid noise from low-traffic ASNs; drives the full
+  //     critical/warning/caution ladder.
+  //   • Block rate: fraction of arms the bandit has already flagged as
+  //     blocked. The bandit applies its own minimum-sample threshold before
+  //     flagging, so a high block fraction is meaningful even if the
+  //     recent probe window expired — covers the low-signal case.
   const hasSignal = asn.totalTests != null && asn.totalTests >= 20;
   const errorRate = hasSignal ? (asn.errorRate ?? 0) : 0;
   const blockFrac = asn.numArms > 0 ? asn.numBlocked / asn.numArms : 0;
@@ -576,7 +580,9 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
             </span>
           </Tip>
           {hasSignal && (
-            <Tip text={`${(errorRate * 100).toFixed(1)}% of probe callbacks fail across this ISP's tracks (${asn.totalSuccess}/${asn.totalTests} succeeded in the latest 1-hour window).`}>
+            <Tip text={asn.totalSuccess != null && asn.totalTests != null
+              ? `${(errorRate * 100).toFixed(1)}% of probe callbacks fail across this ISP's tracks (${asn.totalSuccess}/${asn.totalTests} succeeded in the latest 1-hour window).`
+              : `${(errorRate * 100).toFixed(1)}% of probe callbacks fail across this ISP's tracks in the latest 1-hour window.`}>
               <span style={{ ...chipStyle, color: errorRateColor(errorRate) }}>
                 {(errorRate * 100).toFixed(0)}% err <InfoIcon />
               </span>
@@ -850,7 +856,7 @@ function CountryRow({
         </Tip>
 
         {c.avgErrorRate != null && (
-          <Tip text={`${(c.avgErrorRate * 100).toFixed(1)}% of probe callbacks fail in ${countryName(c.country)}. Data window: each ISP's latest ~1-hour tumbling window (snapshots taken every minute; Redis counters reset each hour). Unlike block rate (binary per arm), error rate shows continuous connection quality.`}>
+          <Tip text={`${(c.avgErrorRate * 100).toFixed(1)}% of probe callbacks fail in ${countryName(c.country)}. Data window: each ISP's latest 1-hour rolling window (snapshots taken every minute). Unlike block rate (binary per arm), error rate shows continuous connection quality.`}>
             <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px" }}>
               <MiniBar value={c.avgErrorRate} color={erColor} />
               <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: erColor, minWidth: "32px", textAlign: "right" }}>
@@ -1120,7 +1126,7 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
             <div style={cardHint}>of arms blocked across all ISPs</div>
           </div>
         </Tip>
-        <Tip text="Percentage of probe callbacks that fail, weighted by probe volume across all ISPs. Data window: each ISP's latest ~1-hour tumbling window (snapshots every minute; Redis signal counters reset each hour). Unlike block rate (binary: an arm is either blocked or not), error rate shows continuous connection quality. A country may have 0% block rate but 30% error rate — meaning connections are degraded but no arms have crossed the blocking threshold.">
+        <Tip text="Percentage of probe callbacks that fail, weighted by probe volume across all ISPs. Data window: each ISP's latest 1-hour rolling window (snapshots every minute). Unlike block rate (binary: an arm is either blocked or not), error rate shows continuous connection quality. A country may have 0% block rate but 30% error rate — meaning connections are degraded but no arms have crossed the blocking threshold.">
           <div style={card}>
             <div style={cardLabel}>Avg Error Rate <InfoIcon /></div>
             <div style={{ ...cardValue, color: weightedErrorRate != null ? errorRateColor(weightedErrorRate) : "#667080" }}>

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -481,6 +481,46 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
   const name = asnDisplayName(asn.asn, asnDB);
   const blockedColor = asn.numBlocked > 0 ? "#e06060" : "#667080";
 
+  // Severity is derived from error rate (primary signal) and block rate as a
+  // secondary amplifier. High error rate without blocks = degraded but not
+  // censored; high block rate = active censorship. Either warrants a visible
+  // warning. Requires ≥20 probe tests to avoid noise from low-traffic ASNs.
+  const hasSignal = asn.totalTests != null && asn.totalTests >= 20;
+  const errorRate = hasSignal ? (asn.errorRate ?? 0) : 0;
+  const blockFrac = asn.numArms > 0 ? asn.numBlocked / asn.numArms : 0;
+  let severity: "critical" | "warning" | "caution" | "ok" = "ok";
+  if (hasSignal) {
+    if (errorRate > 0.5 || blockFrac > 0.5) severity = "critical";
+    else if (errorRate > 0.2 || blockFrac > 0.2) severity = "warning";
+    else if (errorRate > 0.05) severity = "caution";
+  } else if (blockFrac > 0.5) {
+    severity = "critical";
+  } else if (blockFrac > 0.2) {
+    severity = "warning";
+  }
+  const severityBg: Record<typeof severity, string> = {
+    critical: "rgba(224,96,96,0.08)",
+    warning:  "rgba(224,160,128,0.07)",
+    caution:  "rgba(216,192,144,0.05)",
+    ok:       "rgba(255,255,255,0.008)",
+  };
+  const severityHoverBg: Record<typeof severity, string> = {
+    critical: "rgba(224,96,96,0.14)",
+    warning:  "rgba(224,160,128,0.12)",
+    caution:  "rgba(216,192,144,0.09)",
+    ok:       "rgba(255,255,255,0.02)",
+  };
+  const severityBorder: Record<typeof severity, string> = {
+    critical: "2px solid #e06060",
+    warning:  "2px solid #e0a080",
+    caution:  "2px solid #d8c090",
+    ok:       "2px solid transparent",
+  };
+  const nameColor = severity === "critical" ? "#ffb0b0"
+    : severity === "warning" ? "#f0c8a8"
+    : severity === "caution" ? "#e8d8a8"
+    : "#c0c8d4";
+
   // Live-fetched full arm set (vs snapshot top-N). Loaded on demand when the
   // user clicks "Show all arms" — reads directly from Redis on the server,
   // so it's fresher than the snapshot and uncapped.
@@ -518,13 +558,13 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
   return (
     <div>
       <div
-        style={ispRowStyle}
+        style={{ ...ispRowStyle, background: severityBg[severity], borderLeft: severityBorder[severity] }}
         onClick={() => toggleASN(key)}
-        onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.02)"; }}
-        onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.008)"; }}
+        onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = severityHoverBg[severity]; }}
+        onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = severityBg[severity]; }}
       >
         <span style={chevronStyle(expanded)}>&#9662;</span>
-        <span style={{ fontWeight: 600, color: "#c0c8d4" }}>{name}</span>
+        <span style={{ fontWeight: 600, color: nameColor }}>{name}</span>
         <span style={{ fontSize: "0.65rem", color: "#667080" }}>{name !== asn.asn ? asn.asn : ""}</span>
         <span style={{ marginLeft: "auto", display: "flex", gap: "0.5rem", alignItems: "center" }}>
           <span style={chipStyle}>
@@ -535,6 +575,13 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
               {asn.numBlocked}/{asn.numArms} blocked <InfoIcon />
             </span>
           </Tip>
+          {hasSignal && (
+            <Tip text={`${(errorRate * 100).toFixed(1)}% of probe callbacks fail across this ISP's tracks (${asn.totalSuccess}/${asn.totalTests} succeeded in the latest 1-hour window).`}>
+              <span style={{ ...chipStyle, color: errorRateColor(errorRate) }}>
+                {(errorRate * 100).toFixed(0)}% err <InfoIcon />
+              </span>
+            </Tip>
+          )}
           <span style={chipStyle}>{asn.totalPulls.toLocaleString()} pulls</span>
         </span>
       </div>

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -768,6 +768,17 @@ function CountryRow({
   const erColor = c.avgErrorRate != null ? errorRateColor(c.avgErrorRate) : "#556070";
   const nameColor = countryHealthColor(c);
 
+  // Top 3 worst ASNs by error rate — only shown for primary censored countries
+  // to avoid clutter. Requires cached ASN data (fetched for all countries in a
+  // 30s background loop).
+  const worstASNs = useMemo(() => {
+    if (!PRIMARY_COUNTRIES.has(c.country) || !asns) return [];
+    return asns
+      .filter((a) => a.totalTests != null && a.totalTests > 20 && a.errorRate != null)
+      .sort((a, b) => (b.errorRate ?? 0) - (a.errorRate ?? 0))
+      .slice(0, 3);
+  }, [c.country, asns]);
+
   return (
     <div>
       <div
@@ -792,7 +803,7 @@ function CountryRow({
         </Tip>
 
         {c.avgErrorRate != null && (
-          <Tip text={`${(c.avgErrorRate * 100).toFixed(1)}% of probe callbacks fail in ${countryName(c.country)}. Unlike block rate (binary per arm), error rate shows continuous connection quality.`}>
+          <Tip text={`${(c.avgErrorRate * 100).toFixed(1)}% of probe callbacks fail in ${countryName(c.country)}. Data window: each ISP's latest ~1-hour tumbling window (snapshots taken every minute; Redis counters reset each hour). Unlike block rate (binary per arm), error rate shows continuous connection quality.`}>
             <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px" }}>
               <MiniBar value={c.avgErrorRate} color={erColor} />
               <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: erColor, minWidth: "32px", textAlign: "right" }}>
@@ -811,6 +822,28 @@ function CountryRow({
           </span>
         </Tip>
       </div>
+
+      {worstASNs.length > 0 && !expanded && (
+        <div style={{
+          display: "flex", alignItems: "center", gap: "0.4rem",
+          padding: "0.1rem 0.75rem 0.3rem 2rem",
+          fontFamily: "var(--font-mono)", fontSize: "0.6rem", color: "#8890a0",
+          flexWrap: "wrap",
+        }}>
+          <span style={{ color: "#556070", letterSpacing: "0.03em" }}>Worst ISPs:</span>
+          {worstASNs.map((a, i) => {
+            const rate = a.errorRate ?? 0;
+            const color = errorRateColor(rate);
+            return (
+              <span key={a.asn}>
+                <span style={{ color: "#a0b0c8" }}>{asnDisplayName(a.asn, asnDB)}</span>
+                <span style={{ color, marginLeft: "0.25rem" }}>{(rate * 100).toFixed(0)}%</span>
+                {i < worstASNs.length - 1 && <span style={{ color: "#2a3040", margin: "0 0.15rem" }}>·</span>}
+              </span>
+            );
+          })}
+        </div>
+      )}
 
       {expanded && (
         <div>
@@ -1040,7 +1073,7 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
             <div style={cardHint}>of arms blocked across all ISPs</div>
           </div>
         </Tip>
-        <Tip text="Percentage of probe callbacks that fail. Unlike block rate (binary: an arm is either blocked or not), error rate shows continuous connection quality. A country may have 0% block rate but 30% error rate — meaning connections are degraded but no arms have crossed the blocking threshold.">
+        <Tip text="Percentage of probe callbacks that fail, weighted by probe volume across all ISPs. Data window: each ISP's latest ~1-hour tumbling window (snapshots every minute; Redis signal counters reset each hour). Unlike block rate (binary: an arm is either blocked or not), error rate shows continuous connection quality. A country may have 0% block rate but 30% error rate — meaning connections are degraded but no arms have crossed the blocking threshold.">
           <div style={card}>
             <div style={cardLabel}>Avg Error Rate <InfoIcon /></div>
             <div style={{ ...cardValue, color: weightedErrorRate != null ? errorRateColor(weightedErrorRate) : "#667080" }}>

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -792,7 +792,7 @@ function CountryRow({
         </Tip>
 
         {c.avgErrorRate != null && (
-          <Tip text={`${(c.avgErrorRate * 100).toFixed(1)}% of probes fail in ${countryName(c.country)}. Unlike block rate (binary per arm), error rate shows continuous connection quality.`}>
+          <Tip text={`${(c.avgErrorRate * 100).toFixed(1)}% of probe callbacks fail in ${countryName(c.country)}. Unlike block rate (binary per arm), error rate shows continuous connection quality.`}>
             <div style={{ display: "flex", alignItems: "center", gap: "4px", width: "80px" }}>
               <MiniBar value={c.avgErrorRate} color={erColor} />
               <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: erColor, minWidth: "32px", textAlign: "right" }}>
@@ -947,9 +947,9 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
     return countries.reduce((s, c) => s + c.avgEntropy * c.asnCount, 0) / totalWeight;
   }, [countries]);
 
-  const weightedErrorRate = useMemo(() => {
+  const weightedErrorRate = useMemo((): number | null => {
     const totalTests = countries.reduce((s, c) => s + (c.totalTests ?? 0), 0);
-    if (totalTests === 0) return 0;
+    if (totalTests === 0) return null;
     const totalSuccess = countries.reduce((s, c) => s + (c.totalSuccess ?? 0), 0);
     return 1 - totalSuccess / totalTests;
   }, [countries]);
@@ -1043,8 +1043,8 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
         <Tip text="Percentage of probe callbacks that fail. Unlike block rate (binary: an arm is either blocked or not), error rate shows continuous connection quality. A country may have 0% block rate but 30% error rate — meaning connections are degraded but no arms have crossed the blocking threshold.">
           <div style={card}>
             <div style={cardLabel}>Avg Error Rate <InfoIcon /></div>
-            <div style={{ ...cardValue, color: errorRateColor(weightedErrorRate) }}>
-              {(weightedErrorRate * 100).toFixed(1)}%
+            <div style={{ ...cardValue, color: weightedErrorRate != null ? errorRateColor(weightedErrorRate) : "#667080" }}>
+              {weightedErrorRate != null ? `${(weightedErrorRate * 100).toFixed(1)}%` : "N/A"}
             </div>
             <div style={cardHint}>probe callback failures</div>
           </div>


### PR DESCRIPTION
## Summary

When a country is expanded on the Arms tab, individual ISP rows are now visually marked by severity so troubled ISPs pop out at a glance:

| Severity | Trigger | Visual |
|----------|---------|--------|
| critical | >50% error rate OR >50% arms blocked | Red left border, reddish tint, light-red name |
| warning  | >20% error rate OR >20% arms blocked | Orange left border, orange tint |
| caution  | >5% error rate                       | Yellow left border, yellow tint |
| ok       | below all thresholds                 | unchanged |

Also added a per-ISP \"X% err\" chip (complementary to the existing \"N/M blocked\" chip).

## Gating

- Error rate–based severity requires **≥20 probe tests** in the ISP's 1-hour window (avoids noise from low-traffic ASNs).
- Block rate–based severity has no such gate: the bandit applies its own minimum-sample threshold before flagging arms as blocked, so a high block fraction is meaningful even when the recent probe window has expired.

## Test plan

- [ ] Expand Russia / Iran / China — the worst ISPs from the \"Worst ISPs\" line should visibly match the critically-colored rows in the expanded list
- [ ] Hover over a red row — tooltip on the \"err\" chip shows success/total counts and 1-hour window
- [ ] ISPs with <20 probes don't get colored by error rate alone (require blocked arms to escalate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)