### PR TITLE
feat(arms): flag VPN-origin ASNs separately from residential ISPs

### DIFF
--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -121,6 +121,47 @@ const ASN_NAMES: Record<string, string> = {
   AS2856: "BT", AS6461: "Zayo", AS174: "Cogent",
 };
 
+// Hosting / VPN / cloud provider ASNs. When a client connects to Lantern via
+// another VPN, Lantern sees the connection coming from that VPN's egress ASN
+// rather than a residential ISP. These ASNs show up with high error rates
+// that don't reflect real Lantern connectivity — most visible in DE/UK/NL.
+// Treat them as a separate category in the UI.
+const VPN_ORIGIN_ASNS = new Set([
+  // CDN / hyperscalers
+  "AS13335",  // Cloudflare
+  "AS15169",  // Google
+  "AS16509",  // Amazon AWS
+  "AS14618",  // Amazon AWS
+  "AS8075",   // Microsoft (Azure)
+  "AS32934",  // Facebook
+  "AS15133",  // Edgecast
+  "AS54113",  // Fastly
+  "AS20940",  // Akamai
+  // Hosting providers common for self-hosted VPNs
+  "AS24940",  // Hetzner
+  "AS14061",  // DigitalOcean
+  "AS16276",  // OVH
+  "AS63949",  // Linode / Akamai Connected Cloud
+  "AS20473",  // Choopa / Vultr
+  "AS9009",   // M247
+  "AS29802",  // HVC (Choopa)
+  "AS46606",  // Unified Layer
+  "AS36351",  // SoftLayer / IBM
+  "AS26496",  // GoDaddy
+  // Commercial VPN-associated
+  "AS62240",  // Clouvider (used by Mullvad, others)
+  "AS16125",  // UAB Cherry Servers
+  "AS202425", // IP Volume inc (used by Mullvad)
+  "AS51167",  // Contabo
+  "AS8560",   // IONOS
+]);
+
+function isVPNOriginASN(asn: string): boolean {
+  if (VPN_ORIGIN_ASNS.has(asn)) return true;
+  const withPrefix = asn.startsWith("AS") ? asn : `AS${asn}`;
+  return VPN_ORIGIN_ASNS.has(withPrefix);
+}
+
 function asnDisplayName(asn: string, db: Record<string, string> | null): string {
   // The inline map uses "AS44244" keys
   if (ASN_NAMES[asn]) return ASN_NAMES[asn];
@@ -480,6 +521,7 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
   const expanded = expandedASNs.has(key);
   const name = asnDisplayName(asn.asn, asnDB);
   const blockedColor = asn.numBlocked > 0 ? "#e06060" : "#667080";
+  const isVPNOrigin = isVPNOriginASN(asn.asn);
 
   // Severity combines two independent signals:
   //   • Error rate: from Redis ASN signals (1-hour window). Requires ≥20
@@ -502,6 +544,11 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
   } else if (blockFrac > 0.2) {
     severity = "warning";
   }
+  // VPN-origin ASNs get capped severity — high error rates here usually
+  // reflect double-VPN breakage, not censorship, and shouldn't trigger the
+  // same visual alarm as real ISP blocking.
+  if (isVPNOrigin && severity === "critical") severity = "warning";
+  if (isVPNOrigin && severity === "warning") severity = "caution";
   const severityBg: Record<typeof severity, string> = {
     critical: "rgba(224,96,96,0.08)",
     warning:  "rgba(224,160,128,0.07)",
@@ -570,6 +617,19 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
         <span style={chevronStyle(expanded)}>&#9662;</span>
         <span style={{ fontWeight: 600, color: nameColor }}>{name}</span>
         <span style={{ fontSize: "0.65rem", color: "#667080" }}>{name !== asn.asn ? asn.asn : ""}</span>
+        {isVPNOrigin && (
+          <Tip text="This is a hosting/VPN provider ASN. Connections from here are almost certainly users running Lantern on top of another VPN. High error rates usually reflect the double-VPN setup, not censorship.">
+            <span style={{
+              fontSize: "0.55rem", color: "#8890a0",
+              background: "rgba(136,144,160,0.12)",
+              border: "1px solid rgba(136,144,160,0.25)",
+              borderRadius: "3px", padding: "0.05rem 0.3rem",
+              letterSpacing: "0.04em", fontWeight: 600,
+            }}>
+              VPN ORIGIN
+            </span>
+          </Tip>
+        )}
         <span style={{ marginLeft: "auto", display: "flex", gap: "0.5rem", alignItems: "center" }}>
           <span style={chipStyle}>
             {asn.numArms} arms{allArms ? ` (all shown, live)` : asn.topArms.length < asn.numArms ? ` (top ${asn.topArms.length} shown)` : ""}
@@ -828,9 +888,24 @@ function CountryRow({
     if (!PRIMARY_COUNTRIES.has(c.country) || !asns) return [];
     return asns
       .filter((a) => a.totalTests != null && a.totalTests >= 20 && a.errorRate != null)
+      .filter((a) => !isVPNOriginASN(a.asn)) // VPN-origin ASNs are double-VPN users, not censorship signal
       .sort((a, b) => (b.errorRate ?? 0) - (a.errorRate ?? 0))
       .slice(0, 3);
   }, [c.country, asns]);
+
+  // Split ASNs into residential (real ISPs) and VPN-origin (Cloudflare,
+  // Hetzner, DO etc. — mostly double-VPN users whose error rates don't
+  // reflect real Lantern connectivity).
+  const { residentialASNs, vpnOriginASNs } = useMemo(() => {
+    const residential: DashboardASN[] = [];
+    const vpnOrigin: DashboardASN[] = [];
+    for (const a of asns ?? []) {
+      if (isVPNOriginASN(a.asn)) vpnOrigin.push(a);
+      else residential.push(a);
+    }
+    return { residentialASNs: residential, vpnOriginASNs: vpnOrigin };
+  }, [asns]);
+  const [showVPNOrigin, setShowVPNOrigin] = useState(false);
 
   return (
     <div>
@@ -910,7 +985,7 @@ function CountryRow({
               No ASN data
             </div>
           )}
-          {!loading && asns && asns.map((asn) => (
+          {!loading && residentialASNs.map((asn) => (
             <ISPSection
               key={asn.asn}
               asn={asn}
@@ -923,6 +998,44 @@ function CountryRow({
               onLiveArmsLoaded={handleLiveArmsLoaded}
             />
           ))}
+          {!loading && vpnOriginASNs.length > 0 && (
+            <>
+              <div
+                onClick={() => setShowVPNOrigin((v) => !v)}
+                style={{
+                  display: "flex", alignItems: "center", gap: "0.5rem",
+                  padding: "0.4rem 1.5rem", cursor: "pointer", userSelect: "none",
+                  borderTop: "1px solid #ffffff06", borderBottom: showVPNOrigin ? "1px solid #ffffff06" : "none",
+                  background: "rgba(255,255,255,0.008)",
+                }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.02)"; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = "rgba(255,255,255,0.008)"; }}
+              >
+                <span style={chevronStyle(showVPNOrigin)}>&#9662;</span>
+                <Tip text="These ASNs (Cloudflare, Hetzner, DigitalOcean, OVH, Linode, AWS, Azure, etc.) are hosting/VPN providers. Connections appearing from these ASNs are almost certainly users running Lantern on top of another VPN. Their high error rates don't reflect real Lantern connectivity — the double-VPN setup is the likely cause, not censorship or infrastructure.">
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "#8890a0", letterSpacing: "0.03em" }}>
+                    VPN-origin ASNs ({vpnOriginASNs.length}) <InfoIcon />
+                  </span>
+                </Tip>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.55rem", color: "#556070", fontStyle: "italic", marginLeft: "0.5rem" }}>
+                  likely double-VPN users, not censorship signal
+                </span>
+              </div>
+              {showVPNOrigin && vpnOriginASNs.map((asn) => (
+                <ISPSection
+                  key={asn.asn}
+                  asn={asn}
+                  country={c.country}
+                  expandedASNs={expandedASNs}
+                  toggleASN={toggleASN}
+                  asnDB={asnDB}
+                  regionToCity={regionToCity}
+                  filters={armFilters}
+                  onLiveArmsLoaded={handleLiveArmsLoaded}
+                />
+              ))}
+            </>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Problem

Users running Lantern on top of another VPN (ProtonVPN, Mullvad, custom
WireGuard, etc.) appear to Lantern as connecting from the outer VPN's
egress ASN — typically:

- **CDN / hyperscalers**: Cloudflare (AS13335), Google (AS15169), AWS (AS16509), Microsoft Azure (AS8075), Fastly, Akamai
- **Hosting providers**: Hetzner (AS24940), DigitalOcean (AS14061), OVH (AS16276), Linode (AS63949), Vultr (AS20473), M247, Contabo, IONOS
- **Commercial VPN-associated**: Clouvider, IP Volume (used by Mullvad)

These ASNs show very high error rates on the Arms tab — particularly visible in DE/UK/NL — but the errors aren't censorship. They're double-VPN breakage. Mixing them with real ISP data made country-level error rates misleading (\"Germany has 60% error rate\" when German residential ASNs are fine but the Hetzner pool is failing).

## Changes

- New `VPN_ORIGIN_ASNS` set + `isVPNOriginASN()` helper covering ~25 common hosting/CDN/VPN-adjacent ASNs.
- When a country is expanded, residential ASNs are shown first, VPN-origin ASNs in a separate collapsible \"VPN-origin ASNs (N)\" section below (closed by default, with a tooltip explaining why they're separated).
- VPN-origin ISP rows get a \"VPN ORIGIN\" badge so they're identifiable in isolation.
- Severity coloring for VPN-origin ASNs is capped at \"caution\" — high error rates here reflect double-VPN setup, not censorship.
- \"Worst ISPs\" inline summary (for CN/IR/RU) now excludes VPN-origin ASNs so real residential blocking isn't hidden behind double-VPN noise.

## Test plan

- [ ] Expand Germany / UK / Netherlands — Cloudflare, Hetzner, DigitalOcean, etc. should appear in the \"VPN-origin ASNs\" collapsible section, NOT in the main residential list
- [ ] VPN-origin rows have a \"VPN ORIGIN\" badge after the ASN name
- [ ] Severity coloring on VPN-origin rows: never red, even with very high error rate
- [ ] \"Worst ISPs\" line on Iran / China / Russia (if any of their ASNs happen to be hosting providers — they shouldn't, but check) doesn't include hosting ASNs

## Follow-ups

- Could automate ASN classification via maxmind GeoIP2-ISP \`type=hosting\` tag instead of hardcoded list
- Could surface a \"% real ISP\" vs \"% VPN-origin\" breakdown in country summary metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)