### PR TITLE
feat(feed): render structured reason chip on provision/deprecation events

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -170,6 +170,7 @@ export const EventType = {
   ROUTE_UNBLOCKED: "route_unblocked",
   ROUTE_DEPRECATED: "route_deprecated",
   ROUTE_PROVISIONED: "route_provisioned",
+  ROUTE_PROVISION_STARTED: "route_provision_started",
   CALLBACK: "callback",
 } as const;
 
@@ -181,6 +182,7 @@ export interface DashboardActivityEvent {
   asn?: string;
   routeId?: string;
   detail?: string;
+  reason?: string;
   reward?: number;
   latencyMs?: number;
   timestamp: number;

--- a/src/components/ProtocolFeed.tsx
+++ b/src/components/ProtocolFeed.tsx
@@ -45,8 +45,8 @@ const LIVE_CSS_CLASS: Record<string, string> = {
 
 // Short human-friendly labels for the structured reason codes the API
 // emits alongside route_provision_started / route_deprecated events.
-// Unknown reasons fall through to the raw code (which is already lowercase
-// snake_case, so it still reads reasonably on screen).
+// Unknown reasons fall through to the API code with underscores converted
+// to spaces, so they still read reasonably on screen.
 const REASON_LABELS: Record<string, string> = {
   pool_deficit: "pool deficit",
   capacity_scale_up: "capacity scale-up",
@@ -55,13 +55,17 @@ const REASON_LABELS: Record<string, string> = {
   track_deleted: "track deleted",
 };
 
+// color-mix lets us layer transparency on top of --accent-primary without
+// hard-coding a second palette entry. Appending a hex alpha suffix directly
+// to a var() expression (e.g. `var(--accent-primary)33`) is invalid CSS —
+// the browser parses it as two tokens and drops the declaration.
 const reasonChipStyle: React.CSSProperties = {
   display: "inline-block",
   padding: "1px 6px",
   marginLeft: "6px",
   borderRadius: "3px",
-  border: "1px solid var(--accent-primary, #00e5c8)33",
-  background: "var(--accent-primary, #00e5c8)12",
+  border: "1px solid color-mix(in srgb, var(--accent-primary, #00e5c8) 20%, transparent)",
+  background: "color-mix(in srgb, var(--accent-primary, #00e5c8) 7%, transparent)",
   color: "var(--accent-primary, #00e5c8)",
   fontFamily: "var(--font-mono)",
   fontSize: "0.52rem",

--- a/src/components/ProtocolFeed.tsx
+++ b/src/components/ProtocolFeed.tsx
@@ -21,6 +21,7 @@ const LIVE_TYPE_ICONS: Record<string, string> = {
   [EventType.ROUTE_UNBLOCKED]: "⚡",
   [EventType.ROUTE_DEPRECATED]: "💀",
   [EventType.ROUTE_PROVISIONED]: "🚀",
+  [EventType.ROUTE_PROVISION_STARTED]: "🛠",
   [EventType.CALLBACK]: "📡",
 };
 
@@ -29,6 +30,7 @@ const LIVE_TYPE_LABELS: Record<string, string> = {
   [EventType.ROUTE_UNBLOCKED]: "Block Evaded",
   [EventType.ROUTE_DEPRECATED]: "Route Deprecated",
   [EventType.ROUTE_PROVISIONED]: "Route Deployed",
+  [EventType.ROUTE_PROVISION_STARTED]: "Provisioning",
   [EventType.CALLBACK]: "Probe Callback",
 };
 
@@ -37,7 +39,36 @@ const LIVE_CSS_CLASS: Record<string, string> = {
   [EventType.ROUTE_UNBLOCKED]: "evaded",
   [EventType.ROUTE_DEPRECATED]: "blocked",
   [EventType.ROUTE_PROVISIONED]: "deployed",
+  [EventType.ROUTE_PROVISION_STARTED]: "generated",
   [EventType.CALLBACK]: "generated",
+};
+
+// Short human-friendly labels for the structured reason codes the API
+// emits alongside route_provision_started / route_deprecated events.
+// Unknown reasons fall through to the raw code (which is already lowercase
+// snake_case, so it still reads reasonably on screen).
+const REASON_LABELS: Record<string, string> = {
+  pool_deficit: "pool deficit",
+  capacity_scale_up: "capacity scale-up",
+  blocked_grace: "blocked (grace elapsed)",
+  manual: "manual",
+  track_deleted: "track deleted",
+};
+
+const reasonChipStyle: React.CSSProperties = {
+  display: "inline-block",
+  padding: "1px 6px",
+  marginLeft: "6px",
+  borderRadius: "3px",
+  border: "1px solid var(--accent-primary, #00e5c8)33",
+  background: "var(--accent-primary, #00e5c8)12",
+  color: "var(--accent-primary, #00e5c8)",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.52rem",
+  letterSpacing: "0.02em",
+  textTransform: "uppercase",
+  whiteSpace: "nowrap",
+  verticalAlign: "middle",
 };
 
 // Reward is a sigmoid of callback latency ∈ [0, 1]. ANY callback arriving
@@ -138,6 +169,14 @@ export default function ProtocolFeed({ liveEvents, demoMode }: ProtocolFeedProps
                     {isCallback
                       ? `${callbackFast ? "Route OK" : "Route OK (slow)"}${event.trackName ? ` — ${event.trackName}` : ""}${event.regionName ? ` via ${event.regionName}` : ""}${latencySuffix}`
                       : `${LIVE_TYPE_LABELS[event.eventType] || event.eventType}${event.detail ? `: ${humanizeMs(event.detail)}` : ""}`}
+                    {event.reason && (
+                      <span
+                        style={reasonChipStyle}
+                        title={`Reason code: ${event.reason}`}
+                      >
+                        {REASON_LABELS[event.reason] || event.reason.replace(/_/g, " ")}
+                      </span>
+                    )}
                   </div>
                   <div className="feed-meta">
                     {event.trackName && <span className="feed-protocol">{event.trackName}</span>}


### PR DESCRIPTION
## Summary

- Pairs with lantern-cloud #2621 which adds a structured \`reason\` code to every route provision/deprecation event.
- Renders \`reason\` as a small uppercase chip next to the event title in Protocol Activity, with friendly labels for the known codes (\`pool_deficit\` → \"pool deficit\", \`blocked_grace\` → \"blocked (grace elapsed)\", etc.) and a graceful fallback for unknown codes.
- Adds the new \`route_provision_started\` event type (emitted by the API when the pool worker *starts* a provision, ~1–5 min before the route is live), with its own icon/label so operators see the full story: start → \`pool_deficit\` → minutes later → \`VPS running via OCI in 52s\`.

## Screenshots

Manual check only — I have not deployed the API side yet. Once #2621 lands on staging, the feed events will carry \`reason\` and show chips like:

\`\`\`
🛠  Provisioning: 1 route(s) — running 2/3  [POOL DEFICIT]
💀  Route Deprecated: Blocked for 1h3m (4% success over 212 probes)  [BLOCKED (GRACE ELAPSED)]
\`\`\`

## Test plan

- [x] \`npm run build\` passes (clean tsc + vite bundle).
- [ ] With API deploy of #2621, verify the chip appears in the live feed for at least one of each: \`route_provision_started\`, reaper-driven \`route_deprecated\`, manual \`route_deprecated\`.
- [ ] Verify unknown reason codes still render (snake-case-to-spaces fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)