### PR TITLE
feat(vps): show provision + deprecation reason on each fleet row

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -217,6 +217,8 @@ export interface DashboardVPSRoute {
   vpsInstanceId?: string;
   assignmentCount: number;
   peakAssignmentCount: number;
+  provisionReason?: string;
+  deprecationReason?: string;
   trackName: string;
   protocolName: string;
   locationName?: string;

--- a/src/components/VPSOverview.tsx
+++ b/src/components/VPSOverview.tsx
@@ -34,6 +34,24 @@ function formatUptime(createdISO: string): string {
   return `${minutes}m`;
 }
 
+// Short human-friendly labels for the reason codes the API stamps on
+// vps_routes.provision_reason / deprecation_reason. Unknown codes fall
+// through with underscores replaced by spaces so they still read cleanly
+// on screen (e.g. a future reason code ships before the UI is updated).
+const REASON_LABELS: Record<string, string> = {
+  pool_deficit: "pool deficit",
+  capacity_scale_up: "capacity scale-up",
+  admin_create: "admin create",
+  blocked_grace: "blocked (grace)",
+  manual: "manual",
+  track_deleted: "track deleted",
+  force_release: "force released",
+};
+
+function formatReason(code: string): string {
+  return REASON_LABELS[code] || code.replace(/_/g, " ");
+}
+
 interface RegionGroup {
   regionName: string;
   city?: string;
@@ -415,16 +433,36 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
                           <span style={{ color: "#667080" }}> / {route.peakAssignmentCount}</span>
                         </span>
 
-                        {/* Status / Deprecated badge */}
-                        <span>
+                        {/* Status / Deprecated badge + reason chip */}
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: "0.3rem", flexWrap: "wrap" }}>
                           {isDeprecated ? (
-                            <span style={{ ...badgeBase, background: "#e0606018", color: "#e06060", border: "1px solid #e0606030" }}>
-                              deprecated
-                            </span>
+                            <>
+                              <span style={{ ...badgeBase, background: "#e0606018", color: "#e06060", border: "1px solid #e0606030" }}>
+                                deprecated
+                              </span>
+                              {route.deprecationReason && (
+                                <span
+                                  style={{ ...badgeBase, background: "#e0606010", color: "#d08080", border: "1px solid #e0606020" }}
+                                  title={`deprecation_reason: ${route.deprecationReason}`}
+                                >
+                                  {formatReason(route.deprecationReason)}
+                                </span>
+                              )}
+                            </>
                           ) : (
-                            <span style={{ ...badgeBase, background: `${sc}18`, color: sc, border: `1px solid ${sc}30` }}>
-                              {route.status}
-                            </span>
+                            <>
+                              <span style={{ ...badgeBase, background: `${sc}18`, color: sc, border: `1px solid ${sc}30` }}>
+                                {route.status}
+                              </span>
+                              {route.provisionReason && route.status !== "running" && (
+                                <span
+                                  style={{ ...badgeBase, background: "#ffffff06", color: "#8890a0", border: "1px solid #ffffff10" }}
+                                  title={`provision_reason: ${route.provisionReason}`}
+                                >
+                                  {formatReason(route.provisionReason)}
+                                </span>
+                              )}
+                            </>
                           )}
                         </span>
 


### PR DESCRIPTION
## Summary

Pairs with lantern-cloud #2623, which promotes the reason codes from 10-minute Redis live events onto the \`vps_routes\` table as durable columns.

This PR renders them as small badges next to the status/deprecated badge on every VPS fleet row, so operators can answer *\"why is this VPS deprecated?\"* or *\"why is this route spinning up?\"* directly in the fleet tab without jumping to the Protocol Activity feed.

## Rendering

- **Deprecation reason** — red-muted badge next to the red \`deprecated\` badge. Renders whenever \`deprecationReason\` is set.
- **Provision reason** — neutral grey badge next to the status badge. Only shown for non-\`running\` routes, since a running route's \"why did we start this\" is already historical by the time you're reading it.
- Known codes get friendly labels (\"pool deficit\", \"blocked (grace)\", \"track deleted\"). Unknown codes fall through with underscores replaced by spaces so future API additions degrade gracefully.

## Test plan

- [x] \`npm run build\` clean.
- [ ] After deploy of #2623, confirm newly-provisioned routes show their provision reason chip in \`pending\` / \`provisioning\` / \`configuring\` states.
- [ ] Trigger a reaper deprecation on staging; confirm the resulting deprecated row shows a \"blocked (grace)\" chip next to the deprecated badge.
- [ ] Admin \`PUT /api/v1/routes/{id}\` with \`deprecated=true\` → chip reads \"manual\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)