### PR TITLE
VPS: preserve scroll across refresh

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -220,6 +220,7 @@ export default function Dashboard() {
             routes={vpsData.routes}
             summary={vpsData.summary}
             isLoading={vpsData.isLoading}
+            hasLoaded={vpsData.hasLoaded}
             error={vpsData.error}
           />
         ) : activeTab === "arms" ? (

--- a/src/components/VPSOverview.tsx
+++ b/src/components/VPSOverview.tsx
@@ -6,6 +6,7 @@ interface VPSOverviewProps {
   routes: DashboardVPSRoute[];
   summary: DashboardVPSSummary | null;
   isLoading: boolean;
+  hasLoaded: boolean;
   error: string | null;
 }
 
@@ -134,7 +135,7 @@ const badgeBase: CSSProperties = {
   whiteSpace: "nowrap",
 };
 
-function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
+function VPSOverview({ routes, summary, isLoading, hasLoaded, error }: VPSOverviewProps) {
   const [collapsedRegions, setCollapsedRegions] = useState<Set<string>>(new Set());
   const [copiedRouteId, setCopiedRouteId] = useState<string | null>(null);
   const [bandwidthRoute, setBandwidthRoute] = useState<DashboardVPSRoute | null>(null);
@@ -222,7 +223,7 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
     );
   }
 
-  if (error && routes.length === 0) {
+  if (error && !hasLoaded) {
     return (
       <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", minHeight: 300, color: "#e06060", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
         {error}
@@ -230,7 +231,7 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
     );
   }
 
-  if (routes.length === 0) {
+  if (hasLoaded && routes.length === 0 && !error) {
     return (
       <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", minHeight: 300, color: "#667080", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
         No active VPS routes
@@ -240,11 +241,14 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
 
   return (
     <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.75rem", overflowY: "auto", padding: "0.75rem" }}>
-      {error && (
-        <div style={{ padding: "0.5rem 0.75rem", borderRadius: "var(--radius-md)", background: "#e0606012", border: "1px solid #e0606030", color: "#e06060", fontFamily: "var(--font-mono)", fontSize: "0.65rem" }}>
-          Refresh failed: {error}
-        </div>
-      )}
+      {/* Reserve height for the banner so its appearance/disappearance doesn't shift scroll. */}
+      <div style={{ minHeight: "2rem" }}>
+        {error && (
+          <div style={{ padding: "0.5rem 0.75rem", borderRadius: "var(--radius-md)", background: "#e0606012", border: "1px solid #e0606030", color: "#e06060", fontFamily: "var(--font-mono)", fontSize: "0.65rem" }}>
+            Refresh failed: {error}
+          </div>
+        )}
+      </div>
       {/* Summary Cards */}
       <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
         <div style={card}>

--- a/src/components/VPSOverview.tsx
+++ b/src/components/VPSOverview.tsx
@@ -222,7 +222,7 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
     );
   }
 
-  if (error) {
+  if (error && routes.length === 0) {
     return (
       <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", minHeight: 300, color: "#e06060", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
         {error}
@@ -240,6 +240,11 @@ function VPSOverview({ routes, summary, isLoading, error }: VPSOverviewProps) {
 
   return (
     <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.75rem", overflowY: "auto", padding: "0.75rem" }}>
+      {error && (
+        <div style={{ padding: "0.5rem 0.75rem", borderRadius: "var(--radius-md)", background: "#e0606012", border: "1px solid #e0606030", color: "#e06060", fontFamily: "var(--font-mono)", fontSize: "0.65rem" }}>
+          Refresh failed: {error}
+        </div>
+      )}
       {/* Summary Cards */}
       <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
         <div style={card}>

--- a/src/hooks/useVPSData.ts
+++ b/src/hooks/useVPSData.ts
@@ -12,15 +12,18 @@ export function useVPSData(enabled: boolean) {
   useEffect(() => {
     if (!enabled || !isAuthenticated) return;
     let cancelled = false;
+    let isFirst = true;
 
     const refresh = async () => {
-      setIsLoading(true);
+      if (isFirst) setIsLoading(true);
       try {
         const data = await fetchInfrastructure(true);
         if (cancelled) return;
         if (!data.vpsRoutes) {
-          setRoutes([]);
-          setSummary(null);
+          if (isFirst) {
+            setRoutes([]);
+            setSummary(null);
+          }
           setError("VPS route data unavailable");
           return;
         }
@@ -30,7 +33,8 @@ export function useVPSData(enabled: boolean) {
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load VPS data");
       } finally {
-        if (!cancelled) setIsLoading(false);
+        if (!cancelled && isFirst) setIsLoading(false);
+        isFirst = false;
       }
     };
 

--- a/src/hooks/useVPSData.ts
+++ b/src/hooks/useVPSData.ts
@@ -7,6 +7,7 @@ export function useVPSData(enabled: boolean) {
   const [routes, setRoutes] = useState<DashboardVPSRoute[]>([]);
   const [summary, setSummary] = useState<DashboardVPSSummary | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -30,6 +31,7 @@ export function useVPSData(enabled: boolean) {
         setRoutes(data.vpsRoutes.routes);
         setSummary(data.vpsRoutes.summary);
         setError(null);
+        setHasLoaded(true);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load VPS data");
       } finally {
@@ -43,5 +45,5 @@ export function useVPSData(enabled: boolean) {
     return () => { cancelled = true; clearInterval(interval); };
   }, [enabled, isAuthenticated]);
 
-  return { routes, summary, isLoading, error };
+  return { routes, summary, isLoading, hasLoaded, error };
 }


### PR DESCRIPTION
Keep scroll position (and hover/selection state) on the 60s VPS refresh.

Three small changes:

1. **useVPSData**: only set \`isLoading=true\` on the initial load. Previously every tick unmounted the table (via the \`isLoading\` branch in VPSOverview) and remounted it 200ms later with \`scrollTop=0\`.
2. **useVPSData**: don't blank existing \`routes\`/\`summary\` on a transient missing \`data.vpsRoutes\` — just surface the error.
3. **VPSOverview**: if an error arrives mid-session while we already have data, render it as an inline banner above the table instead of replacing the whole view.

Rows are already keyed by \`route.id\`, so React reconciliation keeps everything in place once the table stops unmounting.

## Test plan

- [x] \`tsc -b\` clean
- [ ] Manual: scroll to the bottom of the VPS table, wait ~60s for refresh, confirm scroll stays put
- [ ] Manual: simulate a 500 from \`/v1/dashboard/infrastructure\` (block in devtools) → confirm red banner appears above the existing table instead of replacing it