### PR TITLE
Bandwidth tab: aggregate + per-track bandit throughput with filters

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -353,6 +353,69 @@ export interface TrackMetrics {
   selections: Record<string, number>;        // track name → selection count
 }
 
+// BandwidthFilters drives queries on the Bandwidth tab.
+// Any field left undefined/empty means "no filter on this dimension".
+export interface BandwidthFilters {
+  country?: string;           // ISO-2, matches `country` attribute on proxy.io
+  tier?: "pro" | "free";      // maps to client.is_pro = true|false
+  protocol?: string;          // matches `proxy.protocol` resource attribute
+}
+
+function filterItems(f: BandwidthFilters): object[] {
+  const items: object[] = [
+    { key: { key: "network.io.direction", dataType: "string", type: "tag", isColumn: false, isJSON: false }, op: "=", value: "transmit" },
+  ];
+  if (f.country) {
+    items.push({ key: { key: "country", dataType: "string", type: "tag", isColumn: false, isJSON: false }, op: "=", value: f.country });
+  }
+  if (f.tier) {
+    items.push({ key: { key: "client.is_pro", dataType: "bool", type: "tag", isColumn: false, isJSON: false }, op: "=", value: f.tier === "pro" });
+  }
+  if (f.protocol) {
+    items.push({ key: { key: "proxy.protocol", dataType: "string", type: "tag", isColumn: false, isJSON: false }, op: "=", value: f.protocol });
+  }
+  return items;
+}
+
+// Build a SigNoz query for proxy.io as bytes/sec, optionally grouped by `proxy.track`.
+export function buildBandwidthQuery(opts: {
+  filters: BandwidthFilters;
+  groupByTrack: boolean;
+  startMs: number;
+  endMs: number;
+  stepSeconds: number;
+}): object {
+  return {
+    start: opts.startMs,
+    end: opts.endMs,
+    compositeQuery: {
+      queryType: "builder",
+      panelType: "graph",
+      builderQueries: {
+        A: {
+          dataSource: "metrics",
+          queryName: "A",
+          aggregateAttribute: { key: "proxy.io", dataType: "float64", type: "Sum", isColumn: true, isJSON: false },
+          timeAggregation: "rate",
+          spaceAggregation: "sum",
+          filters: { items: filterItems(opts.filters), op: "AND" },
+          expression: "A",
+          disabled: false,
+          groupBy: opts.groupByTrack
+            ? [{ key: "proxy.track", dataType: "string", type: "tag", isColumn: false, isJSON: false }]
+            : [],
+          legend: opts.groupByTrack ? "{{proxy.track}}" : "total",
+          having: [],
+          limit: null,
+          orderBy: [],
+          reduceTo: "avg",
+          stepInterval: opts.stepSeconds,
+        },
+      },
+    },
+  };
+}
+
 // ── Admin actions ──
 
 export interface BanditResetResponse {

--- a/src/components/BandwidthOverview.tsx
+++ b/src/components/BandwidthOverview.tsx
@@ -124,10 +124,14 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
   }, [tracks]);
 
   // Merge per-track time series into wide-format rows for the stacked area chart.
-  const { chartData, trackKeys, trackColor } = useMemo(() => {
+  const { chartData, trackKeys, trackColor, trackGradientId } = useMemo(() => {
     const keys = (data?.byTrack ?? []).map((s) => s.key).sort();
     const colorMap: Record<string, string> = {};
-    keys.forEach((k, i) => { colorMap[k] = COLORS[i % COLORS.length]; });
+    const gradientIdMap: Record<string, string> = {};
+    keys.forEach((k, i) => {
+      colorMap[k] = COLORS[i % COLORS.length];
+      gradientIdMap[k] = `bw-${i}`;
+    });
 
     const byTs = new Map<number, Record<string, number>>();
     for (const s of data?.byTrack ?? []) {
@@ -139,7 +143,7 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
     const rows = Array.from(byTs.values())
       .map((r) => ({ ...r, ts: Number(r.ts) }))
       .sort((a, b) => a.ts - b.ts);
-    return { chartData: rows, trackKeys: keys, trackColor: colorMap };
+    return { chartData: rows, trackKeys: keys, trackColor: colorMap, trackGradientId: gradientIdMap };
   }, [data]);
 
   const trackTotals = useMemo(() => {
@@ -147,35 +151,18 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
     const windowSec = windowDays * 86400;
     return (data.byTrack ?? [])
       .map((s) => {
-        let totalBytes = 0;
-        let maxBps = 0;
-        for (let i = 0; i < s.points.length; i++) {
-          const p = s.points[i];
-          const next = s.points[i + 1];
-          const dt = next ? (next.ts - p.ts) / 1000 : 0;
-          if (dt > 0) totalBytes += p.value * dt;
-          if (p.value > maxBps) maxBps = p.value;
-        }
-        const avgBps = windowSec > 0 ? totalBytes / windowSec : 0;
-        return { key: s.key, totalBytes, avgBps, maxBps };
+        const { totalBytes, maxBytesPerSec } = integrateRate(s.points);
+        const avgBytesPerSec = windowSec > 0 ? totalBytes / windowSec : 0;
+        return { key: s.key, totalBytes, avgBytesPerSec, maxBytesPerSec };
       })
       .sort((a, b) => b.totalBytes - a.totalBytes);
   }, [data, windowDays]);
 
   const aggregate = useMemo(() => {
-    const points = data?.total?.points ?? [];
-    let totalBytes = 0;
-    let maxBps = 0;
-    for (let i = 0; i < points.length; i++) {
-      const p = points[i];
-      const next = points[i + 1];
-      const dt = next ? (next.ts - p.ts) / 1000 : 0;
-      if (dt > 0) totalBytes += p.value * dt;
-      if (p.value > maxBps) maxBps = p.value;
-    }
+    const { totalBytes, maxBytesPerSec } = integrateRate(data?.total?.points ?? []);
     const windowSec = windowDays * 86400;
-    const avgBps = totalBytes / windowSec;
-    return { totalBytes, avgBps, maxBps };
+    const avgBytesPerSec = windowSec > 0 ? totalBytes / windowSec : 0;
+    return { totalBytes, avgBytesPerSec, maxBytesPerSec };
   }, [data, windowDays]);
 
   const hasSelectedFilters = !!(country || tier || protocol);
@@ -247,11 +234,11 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
       <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
         <div style={card}>
           <div style={cardLabel}>Avg bandwidth</div>
-          <div style={{ ...cardValue, color: "#00e5c8" }}>{formatBps(aggregate.avgBps)}</div>
+          <div style={{ ...cardValue, color: "#00e5c8" }}>{formatBytesPerSec(aggregate.avgBytesPerSec)}</div>
         </div>
         <div style={card}>
           <div style={cardLabel}>Peak bandwidth</div>
-          <div style={{ ...cardValue, color: "#80b0e0" }}>{formatBps(aggregate.maxBps)}</div>
+          <div style={{ ...cardValue, color: "#80b0e0" }}>{formatBytesPerSec(aggregate.maxBytesPerSec)}</div>
         </div>
         <div style={card}>
           <div style={cardLabel}>Total egress</div>
@@ -286,7 +273,7 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
               <AreaChart data={chartData} margin={{ top: 8, right: 16, bottom: 4, left: 8 }}>
                 <defs>
                   {trackKeys.map((k) => (
-                    <linearGradient key={k} id={`bw-${k}`} x1="0" y1="0" x2="0" y2="1">
+                    <linearGradient key={k} id={trackGradientId[k]} x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%" stopColor={trackColor[k]} stopOpacity={0.55} />
                       <stop offset="95%" stopColor={trackColor[k]} stopOpacity={0.05} />
                     </linearGradient>
@@ -307,12 +294,12 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
                   axisLine={false}
                   tickLine={false}
                   width={64}
-                  tickFormatter={(v: number) => formatBps(v)}
+                  tickFormatter={(v: number) => formatBytesPerSec(v)}
                 />
                 <Tooltip
                   contentStyle={{ background: "#1a2030", border: "1px solid #ffffff10", borderRadius: 6, fontSize: "0.65rem", fontFamily: "var(--font-mono)" }}
                   labelFormatter={(ts) => new Date(Number(ts)).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
-                  formatter={(v, name) => [formatBps(Number(v)), name as string]}
+                  formatter={(v, name) => [formatBytesPerSec(Number(v)), name as string]}
                 />
                 <Legend wrapperStyle={{ fontSize: "0.6rem", fontFamily: "var(--font-mono)" }} />
                 {trackKeys.map((k) => (
@@ -323,7 +310,7 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
                     stackId="1"
                     stroke={trackColor[k]}
                     strokeWidth={1}
-                    fill={`url(#bw-${k})`}
+                    fill={`url(#${trackGradientId[k]})`}
                     dot={false}
                     isAnimationActive={false}
                   />
@@ -350,7 +337,7 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
             <div key={t.key} style={trackRowStyle}>
               <span style={{ width: 8, height: 8, borderRadius: "50%", background: trackColor[t.key] ?? "#667080", boxShadow: `0 0 5px ${trackColor[t.key] ?? "#667080"}60` }} />
               <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{t.key}</span>
-              <span style={{ textAlign: "right", color: "#a0a8b8" }}>{formatBps(t.avgBps)}</span>
+              <span style={{ textAlign: "right", color: "#a0a8b8" }}>{formatBytesPerSec(t.avgBytesPerSec)}</span>
               <span style={{ textAlign: "right" }}>{formatBytes(t.totalBytes)}</span>
             </div>
           ))
@@ -360,13 +347,39 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
   );
 }
 
-function formatBps(bps: number): string {
-  if (!Number.isFinite(bps) || bps <= 0) return "0 B/s";
+function formatBytesPerSec(bytesPerSec: number): string {
+  if (!Number.isFinite(bytesPerSec) || bytesPerSec <= 0) return "0 B/s";
   const units = ["B/s", "KB/s", "MB/s", "GB/s", "TB/s"];
-  let v = bps;
+  let v = bytesPerSec;
   let i = 0;
   while (v >= 1000 && i < units.length - 1) { v /= 1000; i++; }
   return `${v.toFixed(v < 10 ? 2 : v < 100 ? 1 : 0)} ${units[i]}`;
+}
+
+// integrateRate converts rate samples (bytes/sec, timestamp in ms) into total bytes
+// over the observed window. Uses the step size inferred from sample gaps to credit
+// the final sample with a full bucket's worth of time (otherwise the last bucket is
+// dropped and egress/avg are systematically low).
+function integrateRate(points: Array<{ ts: number; value: number }>): { totalBytes: number; maxBytesPerSec: number } {
+  if (points.length === 0) return { totalBytes: 0, maxBytesPerSec: 0 };
+  // Median gap as the assumed step; falls back to the first gap if <3 points.
+  let step = 0;
+  if (points.length >= 2) {
+    const gaps: number[] = [];
+    for (let i = 1; i < points.length; i++) gaps.push((points[i].ts - points[i - 1].ts) / 1000);
+    gaps.sort((a, b) => a - b);
+    step = gaps[Math.floor(gaps.length / 2)] || 0;
+  }
+  let totalBytes = 0;
+  let maxBytesPerSec = 0;
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    const next = points[i + 1];
+    const dt = next ? (next.ts - p.ts) / 1000 : step;
+    if (dt > 0) totalBytes += p.value * dt;
+    if (p.value > maxBytesPerSec) maxBytesPerSec = p.value;
+  }
+  return { totalBytes, maxBytesPerSec };
 }
 
 function formatBytes(bytes: number): string {

--- a/src/components/BandwidthOverview.tsx
+++ b/src/components/BandwidthOverview.tsx
@@ -1,0 +1,379 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { Area, AreaChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { useBanditBandwidth } from "../hooks/useBanditBandwidth";
+import { fetchTracks, type DashboardCountry, type DashboardTrackDetail, type BandwidthFilters } from "../api/client";
+
+interface BandwidthOverviewProps {
+  enabled: boolean;
+  countries: DashboardCountry[];
+}
+
+const WINDOW_OPTIONS: Array<{ label: string; days: number }> = [
+  { label: "24h", days: 1 },
+  { label: "3d", days: 3 },
+  { label: "7d", days: 7 },
+];
+
+const COLORS = [
+  "#00e5c8", "#80b0e0", "#f0a030", "#a0c8a0", "#e06060",
+  "#c090e0", "#e0e080", "#60c0d0", "#d07090", "#80d090",
+];
+
+const card: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  padding: "1rem 1.1rem",
+  minWidth: 0,
+  flex: "1 1 0",
+};
+
+const cardLabel: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.6rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "#8890a0",
+  marginBottom: "0.3rem",
+};
+
+const cardValue: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "1.6rem",
+  fontWeight: 600,
+  lineHeight: 1.15,
+};
+
+const filterSelect: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.7rem",
+  background: "#ffffff08",
+  color: "#c0c8d4",
+  border: "1px solid #ffffff10",
+  borderRadius: "var(--radius-sm)",
+  padding: "0.35rem 0.55rem",
+  outline: "none",
+  cursor: "pointer",
+  minWidth: 0,
+};
+
+const filterLabel: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.55rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  color: "#667080",
+  marginBottom: "0.25rem",
+  display: "block",
+};
+
+const chartCard: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  padding: "1rem 1.1rem",
+};
+
+const tableContainer: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  overflow: "auto",
+};
+
+const trackRowStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "8px 1fr 0.8fr 0.8fr",
+  alignItems: "center",
+  gap: "0.75rem",
+  padding: "0.5rem 1rem",
+  borderBottom: "1px solid #ffffff06",
+  fontSize: "0.65rem",
+  fontFamily: "var(--font-mono)",
+  color: "#c0c8d4",
+};
+
+export default function BandwidthOverview({ enabled, countries }: BandwidthOverviewProps) {
+  const [country, setCountry] = useState("");
+  const [tier, setTier] = useState<"" | "pro" | "free">("");
+  const [protocol, setProtocol] = useState("");
+  const [windowDays, setWindowDays] = useState(7);
+  const [tracks, setTracks] = useState<DashboardTrackDetail[]>([]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    fetchTracks()
+      .then((resp) => { if (!cancelled) setTracks(resp.tracks ?? []); })
+      .catch(() => { /* protocol filter stays empty */ });
+    return () => { cancelled = true; };
+  }, [enabled]);
+
+  const filters: BandwidthFilters = useMemo(() => ({
+    country: country || undefined,
+    tier: tier || undefined,
+    protocol: protocol || undefined,
+  }), [country, tier, protocol]);
+
+  const { data, isLoading, error } = useBanditBandwidth(enabled, filters, windowDays);
+
+  const protocols = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of tracks) if (t.protocol) set.add(t.protocol);
+    return Array.from(set).sort();
+  }, [tracks]);
+
+  // Merge per-track time series into wide-format rows for the stacked area chart.
+  const { chartData, trackKeys, trackColor } = useMemo(() => {
+    const keys = (data?.byTrack ?? []).map((s) => s.key).sort();
+    const colorMap: Record<string, string> = {};
+    keys.forEach((k, i) => { colorMap[k] = COLORS[i % COLORS.length]; });
+
+    const byTs = new Map<number, Record<string, number>>();
+    for (const s of data?.byTrack ?? []) {
+      for (const p of s.points) {
+        if (!byTs.has(p.ts)) byTs.set(p.ts, { ts: p.ts });
+        byTs.get(p.ts)![s.key] = p.value;
+      }
+    }
+    const rows = Array.from(byTs.values())
+      .map((r) => ({ ...r, ts: Number(r.ts) }))
+      .sort((a, b) => a.ts - b.ts);
+    return { chartData: rows, trackKeys: keys, trackColor: colorMap };
+  }, [data]);
+
+  const trackTotals = useMemo(() => {
+    if (!data) return [];
+    const windowSec = windowDays * 86400;
+    return (data.byTrack ?? [])
+      .map((s) => {
+        let totalBytes = 0;
+        let maxBps = 0;
+        for (let i = 0; i < s.points.length; i++) {
+          const p = s.points[i];
+          const next = s.points[i + 1];
+          const dt = next ? (next.ts - p.ts) / 1000 : 0;
+          if (dt > 0) totalBytes += p.value * dt;
+          if (p.value > maxBps) maxBps = p.value;
+        }
+        const avgBps = windowSec > 0 ? totalBytes / windowSec : 0;
+        return { key: s.key, totalBytes, avgBps, maxBps };
+      })
+      .sort((a, b) => b.totalBytes - a.totalBytes);
+  }, [data, windowDays]);
+
+  const aggregate = useMemo(() => {
+    const points = data?.total?.points ?? [];
+    let totalBytes = 0;
+    let maxBps = 0;
+    for (let i = 0; i < points.length; i++) {
+      const p = points[i];
+      const next = points[i + 1];
+      const dt = next ? (next.ts - p.ts) / 1000 : 0;
+      if (dt > 0) totalBytes += p.value * dt;
+      if (p.value > maxBps) maxBps = p.value;
+    }
+    const windowSec = windowDays * 86400;
+    const avgBps = totalBytes / windowSec;
+    return { totalBytes, avgBps, maxBps };
+  }, [data, windowDays]);
+
+  const hasSelectedFilters = !!(country || tier || protocol);
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.75rem", overflowY: "auto", padding: "0.75rem" }}>
+      <div style={{ display: "flex", gap: "0.6rem", flexWrap: "wrap", alignItems: "flex-end" }}>
+        <div style={{ display: "flex", flexDirection: "column", minWidth: 140 }}>
+          <span style={filterLabel}>Country</span>
+          <select style={filterSelect} value={country} onChange={(e) => setCountry(e.target.value)}>
+            <option value="">All</option>
+            {countries.map((c) => (
+              <option key={c.country} value={c.country}>{c.country}</option>
+            ))}
+          </select>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", minWidth: 120 }}>
+          <span style={filterLabel}>Tier</span>
+          <select style={filterSelect} value={tier} onChange={(e) => setTier(e.target.value as "" | "pro" | "free")}>
+            <option value="">All</option>
+            <option value="pro">Pro</option>
+            <option value="free">Free</option>
+          </select>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", minWidth: 140 }}>
+          <span style={filterLabel}>Protocol</span>
+          <select style={filterSelect} value={protocol} onChange={(e) => setProtocol(e.target.value)}>
+            <option value="">All</option>
+            {protocols.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", minWidth: 120 }}>
+          <span style={filterLabel}>Window</span>
+          <select style={filterSelect} value={windowDays} onChange={(e) => setWindowDays(Number(e.target.value))}>
+            {WINDOW_OPTIONS.map((w) => (
+              <option key={w.days} value={w.days}>{w.label}</option>
+            ))}
+          </select>
+        </div>
+        {hasSelectedFilters && (
+          <button
+            type="button"
+            onClick={() => { setCountry(""); setTier(""); setProtocol(""); }}
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.6rem",
+              background: "transparent",
+              color: "#8890a0",
+              border: "1px solid #ffffff10",
+              borderRadius: "var(--radius-sm)",
+              padding: "0.35rem 0.7rem",
+              cursor: "pointer",
+              marginLeft: "auto",
+            }}
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div style={{ padding: "0.5rem 0.75rem", borderRadius: "var(--radius-md)", background: "#e0606012", border: "1px solid #e0606030", color: "#e06060", fontFamily: "var(--font-mono)", fontSize: "0.65rem" }}>
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
+        <div style={card}>
+          <div style={cardLabel}>Avg bandwidth</div>
+          <div style={{ ...cardValue, color: "#00e5c8" }}>{formatBps(aggregate.avgBps)}</div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Peak bandwidth</div>
+          <div style={{ ...cardValue, color: "#80b0e0" }}>{formatBps(aggregate.maxBps)}</div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Total egress</div>
+          <div style={{ ...cardValue, color: "#c0c8d4" }}>{formatBytes(aggregate.totalBytes)}</div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Tracks seen</div>
+          <div style={{ ...cardValue, color: "#a0c8a0" }}>{trackKeys.length}</div>
+        </div>
+      </div>
+
+      <div style={chartCard}>
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: "0.5rem" }}>
+          <div style={{ fontFamily: "var(--font-sans)", fontSize: "0.75rem", fontWeight: 600, color: "#d0d8e4" }}>
+            Bandwidth by track
+          </div>
+          <div style={{ fontFamily: "var(--font-mono)", fontSize: "0.55rem", color: "#667080" }}>
+            {WINDOW_OPTIONS.find((w) => w.days === windowDays)?.label} · stacked · bytes/sec
+          </div>
+        </div>
+        <div style={{ height: 320 }}>
+          {isLoading && !data ? (
+            <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: "#667080", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
+              Loading…
+            </div>
+          ) : chartData.length === 0 ? (
+            <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: "#667080", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}>
+              No bandwidth samples for this filter combination
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chartData} margin={{ top: 8, right: 16, bottom: 4, left: 8 }}>
+                <defs>
+                  {trackKeys.map((k) => (
+                    <linearGradient key={k} id={`bw-${k}`} x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor={trackColor[k]} stopOpacity={0.55} />
+                      <stop offset="95%" stopColor={trackColor[k]} stopOpacity={0.05} />
+                    </linearGradient>
+                  ))}
+                </defs>
+                <CartesianGrid stroke="#ffffff08" vertical={false} />
+                <XAxis
+                  dataKey="ts"
+                  type="number"
+                  domain={["dataMin", "dataMax"]}
+                  tickFormatter={(ts: number) => new Date(ts).toLocaleDateString([], { month: "short", day: "numeric" })}
+                  tick={{ fontSize: 10, fill: "#667080" }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <YAxis
+                  tick={{ fontSize: 10, fill: "#667080" }}
+                  axisLine={false}
+                  tickLine={false}
+                  width={64}
+                  tickFormatter={(v: number) => formatBps(v)}
+                />
+                <Tooltip
+                  contentStyle={{ background: "#1a2030", border: "1px solid #ffffff10", borderRadius: 6, fontSize: "0.65rem", fontFamily: "var(--font-mono)" }}
+                  labelFormatter={(ts) => new Date(Number(ts)).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                  formatter={(v, name) => [formatBps(Number(v)), name as string]}
+                />
+                <Legend wrapperStyle={{ fontSize: "0.6rem", fontFamily: "var(--font-mono)" }} />
+                {trackKeys.map((k) => (
+                  <Area
+                    key={k}
+                    type="monotone"
+                    dataKey={k}
+                    stackId="1"
+                    stroke={trackColor[k]}
+                    strokeWidth={1}
+                    fill={`url(#bw-${k})`}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </AreaChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </div>
+
+      <div style={tableContainer}>
+        <div style={{ ...trackRowStyle, padding: "0.5rem 1rem", color: "#667080", fontSize: "0.5rem", textTransform: "uppercase", letterSpacing: "0.06em", fontFamily: "var(--font-sans)", borderBottom: "1px solid #ffffff08" }}>
+          <span />
+          <span>Track</span>
+          <span style={{ textAlign: "right" }}>Avg</span>
+          <span style={{ textAlign: "right" }}>Total egress</span>
+        </div>
+        {trackTotals.length === 0 ? (
+          <div style={{ padding: "1rem", color: "#667080", fontFamily: "var(--font-mono)", fontSize: "0.7rem", textAlign: "center" }}>
+            No per-track data
+          </div>
+        ) : (
+          trackTotals.map((t) => (
+            <div key={t.key} style={trackRowStyle}>
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: trackColor[t.key] ?? "#667080", boxShadow: `0 0 5px ${trackColor[t.key] ?? "#667080"}60` }} />
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{t.key}</span>
+              <span style={{ textAlign: "right", color: "#a0a8b8" }}>{formatBps(t.avgBps)}</span>
+              <span style={{ textAlign: "right" }}>{formatBytes(t.totalBytes)}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatBps(bps: number): string {
+  if (!Number.isFinite(bps) || bps <= 0) return "0 B/s";
+  const units = ["B/s", "KB/s", "MB/s", "GB/s", "TB/s"];
+  let v = bps;
+  let i = 0;
+  while (v >= 1000 && i < units.length - 1) { v /= 1000; i++; }
+  return `${v.toFixed(v < 10 ? 2 : v < 100 ? 1 : 0)} ${units[i]}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes >= 1e12) return `${(bytes / 1e12).toFixed(2)} TB`;
+  if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(2)} GB`;
+  if (bytes >= 1e6) return `${(bytes / 1e6).toFixed(2)} MB`;
+  if (bytes >= 1e3) return `${(bytes / 1e3).toFixed(2)} KB`;
+  return `${bytes.toFixed(0)} B`;
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -11,6 +11,7 @@ import ProxyWidget from "./ProxyWidget";
 import VPSOverview from "./VPSOverview";
 import BanditArmsOverview, { BanditHowItWorks } from "./BanditArmsOverview";
 import TracksOverview from "./TracksOverview";
+import BandwidthOverview from "./BandwidthOverview";
 import AISummary from "./AISummary";
 import AdminPanel from "./AdminPanel";
 import type { GlobalStats } from "../data/mock";
@@ -34,17 +35,18 @@ function LanternLogo() {
 export default function Dashboard() {
   const { isAuthenticated, user, logout, token } = useAuth();
   const { globalStats, dataCenters, activityEvents, trafficFlows, isLive, blockedRoutes, demoMode, toggleDemoMode } = useLiveData();
-  const [activeTab, setActiveTab] = useState<'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'proxy' | 'admin'>(() => {
+  const [activeTab, setActiveTab] = useState<'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'bandwidth' | 'proxy' | 'admin'>(() => {
     const hash = window.location.hash;
     if (hash === '#overview') return 'overview';
     if (hash === '#vps') return 'vps';
     if (hash === '#arms') return 'arms';
     if (hash === '#tracks') return 'tracks';
+    if (hash === '#bandwidth') return 'bandwidth';
     if (hash === '#proxy') return 'proxy';
     if (hash === '#admin') return 'admin';
     return 'map';
   });
-  const switchTab = useCallback((tab: 'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'proxy' | 'admin') => {
+  const switchTab = useCallback((tab: 'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'bandwidth' | 'proxy' | 'admin') => {
     setActiveTab(tab);
     window.location.hash = tab === 'map' ? '' : `#${tab}`;
   }, []);
@@ -121,7 +123,7 @@ export default function Dashboard() {
           </div>
         </div>
         <div style={{ display: "flex", gap: "0.25rem", marginLeft: "1.5rem" }}>
-          {(["map", "overview", "vps", "arms", "tracks", "proxy", "admin"] as const).map((tab) => (
+          {(["map", "overview", "vps", "arms", "tracks", "bandwidth", "proxy", "admin"] as const).map((tab) => (
             <div
               key={tab}
               onClick={() => switchTab(tab)}
@@ -139,7 +141,7 @@ export default function Dashboard() {
                 letterSpacing: "0.05em",
               }}
             >
-              {{ map: "Map", overview: "Overview", vps: "VPS Fleet", arms: "Bandit Arms", tracks: "Tracks", proxy: "Share Proxy", admin: "Admin" }[tab]}
+              {{ map: "Map", overview: "Overview", vps: "VPS Fleet", arms: "Bandit Arms", tracks: "Tracks", bandwidth: "Bandwidth", proxy: "Share Proxy", admin: "Admin" }[tab]}
             </div>
           ))}
         </div>
@@ -226,6 +228,8 @@ export default function Dashboard() {
           <BanditArmsOverview countries={globalStats.countries} dataCenters={dataCenters} isLive={isLive} />
         ) : activeTab === "tracks" ? (
           <TracksOverview />
+        ) : activeTab === "bandwidth" ? (
+          <BandwidthOverview enabled={activeTab === "bandwidth"} countries={globalStats.countries} />
         ) : activeTab === "proxy" ? (
           <div style={{ flex: 1, padding: "1rem" }}>
             <ProxyWidget {...proxy} />

--- a/src/hooks/useBanditBandwidth.ts
+++ b/src/hooks/useBanditBandwidth.ts
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { buildBandwidthQuery, fetchSigNozMetrics, type BandwidthFilters } from "../api/client";
+import { useAuth } from "./useAuth";
+
+export interface BandwidthSeries {
+  key: string;            // "total" or track name
+  points: Array<{ ts: number; value: number }>;  // value in bytes/sec
+}
+
+export interface BandwidthData {
+  total: BandwidthSeries | null;
+  byTrack: BandwidthSeries[];
+}
+
+interface UseBanditBandwidthResult {
+  data: BandwidthData | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useBanditBandwidth(enabled: boolean, filters: BandwidthFilters, windowDays: number): UseBanditBandwidthResult {
+  const { isAuthenticated } = useAuth();
+  const [data, setData] = useState<BandwidthData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const key = `${enabled}|${filters.country ?? ""}|${filters.tier ?? ""}|${filters.protocol ?? ""}|${windowDays}`;
+
+  useEffect(() => {
+    if (!enabled || !isAuthenticated) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    const endMs = Date.now();
+    const startMs = endMs - windowDays * 86_400_000;
+    const stepSeconds = windowDays > 2 ? 3600 : 300;
+
+    const totalQ = buildBandwidthQuery({ filters, groupByTrack: false, startMs, endMs, stepSeconds });
+    const trackQ = buildBandwidthQuery({ filters, groupByTrack: true,  startMs, endMs, stepSeconds });
+
+    Promise.all([fetchSigNozMetrics(totalQ), fetchSigNozMetrics(trackQ)])
+      .then(([totalResp, trackResp]) => {
+        if (cancelled) return;
+        setData({
+          total: extractTotal(totalResp),
+          byTrack: extractSeries(trackResp),
+        });
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load bandwidth");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, isAuthenticated]);
+
+  return { data, isLoading, error };
+}
+
+function extractTotal(resp: unknown): BandwidthSeries | null {
+  const series = extractSeries(resp);
+  if (series.length === 0) return null;
+  if (series.length === 1) return { key: "total", points: series[0].points };
+  // Fallback: sum across any extra series we weren't expecting.
+  const merged = new Map<number, number>();
+  for (const s of series) {
+    for (const p of s.points) merged.set(p.ts, (merged.get(p.ts) ?? 0) + p.value);
+  }
+  return { key: "total", points: Array.from(merged.entries()).sort((a, b) => a[0] - b[0]).map(([ts, value]) => ({ ts, value })) };
+}
+
+function extractSeries(resp: unknown): BandwidthSeries[] {
+  const out: BandwidthSeries[] = [];
+  const r = resp as { data?: { result?: Array<{ series?: Array<{ labels?: Record<string, string>; values?: Array<{ timestamp?: number | string; value?: number | string }> }> }> } };
+  const results = r?.data?.result ?? [];
+  for (const qr of results) {
+    for (const s of qr.series ?? []) {
+      const label = s.labels?.["proxy.track"] || s.labels?.track || "total";
+      const points = (s.values ?? [])
+        .map((v) => ({ ts: Number(v.timestamp) || 0, value: Number(v.value) || 0 }))
+        .filter((p) => p.ts > 0)
+        .sort((a, b) => a.ts - b.ts);
+      if (points.length > 0) out.push({ key: label, points });
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Adds a **Bandwidth** tab that charts \`proxy.io\` (egress) over a selectable window (24h / 3d / 7d), stacked by track, with filters for country, tier (pro/free), and protocol.

## What you get

- **Filters**: country (from global stats), tier (all/pro/free), protocol (from \`/tracks\`), window (24h/3d/7d). Each change triggers a fresh fetch.
- **Summary cards**: avg bandwidth, peak bandwidth, total egress, track count.
- **Chart**: stacked area by track, 1h buckets on 3d/7d, 5min on 24h, rendered with recharts.
- **Per-track table**: avg bps + total egress, sorted descending by volume.

## How it works

\`fetchSigNozMetrics\` already proxies arbitrary SigNoz v5 builder queries via \`/v1/dashboard/metrics\`. This PR adds \`buildBandwidthQuery\` which emits two variants of the same query — one grouped by \`proxy.track\` for the stacked chart, one ungrouped for the aggregate card — both filtering on \`network.io.direction = transmit\`. Filter values map onto these SigNoz attributes:

| UI | SigNoz attribute | Type |
|---|---|---|
| country | \`country\` | string |
| tier | \`client.is_pro\` | bool |
| protocol | \`proxy.protocol\` | string |

Attribute names were verified against the live \`proxy.io\` metric via \`signoz_get_metrics_field_values\`.

## Test plan

- [x] \`tsc -b\` clean
- [x] \`vite build\` clean
- [x] lint clean on new files
- [ ] Manual: open tab, confirm chart populates; switch country/tier/protocol and confirm chart refetches and renders; confirm switching to 24h window uses finer-grained buckets; confirm clearing filters returns to unfiltered view.