### PR TITLE
Bandwidth: restrict to bandit-managed tracks

### DIFF
--- a/src/components/BandwidthOverview.tsx
+++ b/src/components/BandwidthOverview.tsx
@@ -99,13 +99,23 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
   const [protocol, setProtocol] = useState("");
   const [windowDays, setWindowDays] = useState(7);
   const [tracks, setTracks] = useState<DashboardTrackDetail[]>([]);
+  const [tracksReady, setTracksReady] = useState(false);
+  const [tracksError, setTracksError] = useState(false);
 
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
     fetchTracks()
-      .then((resp) => { if (!cancelled) setTracks(resp.tracks ?? []); })
-      .catch(() => { /* protocol filter stays empty */ });
+      .then((resp) => {
+        if (cancelled) return;
+        setTracks(resp.tracks ?? []);
+        setTracksReady(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setTracksReady(true);
+        setTracksError(true);
+      });
     return () => { cancelled = true; };
   }, [enabled]);
 
@@ -124,12 +134,15 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
   }, [tracks]);
 
   // Restrict every view to bandit-managed tracks (names the lantern-cloud /tracks
-  // endpoint returns). Before tracks load, show nothing rather than all traffic.
+  // endpoint returns). Fall back to unfiltered if /tracks failed outright so a
+  // transient tracks-API outage doesn't blank the whole view.
   const banditSeries = useMemo(() => {
-    if (tracks.length === 0) return [];
+    const all = data?.byTrack ?? [];
+    if (tracksError) return all;
+    if (!tracksReady) return all;
     const names = new Set(tracks.map((t) => t.name));
-    return (data?.byTrack ?? []).filter((s) => names.has(s.key));
-  }, [data, tracks]);
+    return all.filter((s) => names.has(s.key));
+  }, [data, tracks, tracksReady, tracksError]);
 
   // Merge per-track time series into wide-format rows for the stacked area chart.
   const { chartData, trackKeys, trackColor, trackGradientId } = useMemo(() => {
@@ -244,6 +257,11 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
       {error && (
         <div style={{ padding: "0.5rem 0.75rem", borderRadius: "var(--radius-md)", background: "#e0606012", border: "1px solid #e0606030", color: "#e06060", fontFamily: "var(--font-mono)", fontSize: "0.65rem" }}>
           {error}
+        </div>
+      )}
+      {tracksError && (
+        <div style={{ padding: "0.5rem 0.75rem", borderRadius: "var(--radius-md)", background: "#f0a03012", border: "1px solid #f0a03030", color: "#f0a030", fontFamily: "var(--font-mono)", fontSize: "0.65rem" }}>
+          Track list unavailable — showing all tracks (including non-bandit).
         </div>
       )}
 

--- a/src/components/BandwidthOverview.tsx
+++ b/src/components/BandwidthOverview.tsx
@@ -123,9 +123,17 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
     return Array.from(set).sort();
   }, [tracks]);
 
+  // Restrict every view to bandit-managed tracks (names the lantern-cloud /tracks
+  // endpoint returns). Before tracks load, show nothing rather than all traffic.
+  const banditSeries = useMemo(() => {
+    if (tracks.length === 0) return [];
+    const names = new Set(tracks.map((t) => t.name));
+    return (data?.byTrack ?? []).filter((s) => names.has(s.key));
+  }, [data, tracks]);
+
   // Merge per-track time series into wide-format rows for the stacked area chart.
   const { chartData, trackKeys, trackColor, trackGradientId } = useMemo(() => {
-    const keys = (data?.byTrack ?? []).map((s) => s.key).sort();
+    const keys = banditSeries.map((s) => s.key).sort();
     const colorMap: Record<string, string> = {};
     const gradientIdMap: Record<string, string> = {};
     keys.forEach((k, i) => {
@@ -134,7 +142,7 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
     });
 
     const byTs = new Map<number, Record<string, number>>();
-    for (const s of data?.byTrack ?? []) {
+    for (const s of banditSeries) {
       for (const p of s.points) {
         if (!byTs.has(p.ts)) byTs.set(p.ts, { ts: p.ts });
         byTs.get(p.ts)![s.key] = p.value;
@@ -144,26 +152,34 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
       .map((r) => ({ ...r, ts: Number(r.ts) }))
       .sort((a, b) => a.ts - b.ts);
     return { chartData: rows, trackKeys: keys, trackColor: colorMap, trackGradientId: gradientIdMap };
-  }, [data]);
+  }, [banditSeries]);
 
   const trackTotals = useMemo(() => {
-    if (!data) return [];
     const windowSec = windowDays * 86400;
-    return (data.byTrack ?? [])
+    return banditSeries
       .map((s) => {
         const { totalBytes, maxBytesPerSec } = integrateRate(s.points);
         const avgBytesPerSec = windowSec > 0 ? totalBytes / windowSec : 0;
         return { key: s.key, totalBytes, avgBytesPerSec, maxBytesPerSec };
       })
       .sort((a, b) => b.totalBytes - a.totalBytes);
-  }, [data, windowDays]);
+  }, [banditSeries, windowDays]);
 
+  // Aggregate is derived from the filtered per-track series so the summary
+  // cards always agree with the chart/table.
   const aggregate = useMemo(() => {
-    const { totalBytes, maxBytesPerSec } = integrateRate(data?.total?.points ?? []);
+    const summed = new Map<number, number>();
+    for (const s of banditSeries) {
+      for (const p of s.points) summed.set(p.ts, (summed.get(p.ts) ?? 0) + p.value);
+    }
+    const points = Array.from(summed.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([ts, value]) => ({ ts, value }));
+    const { totalBytes, maxBytesPerSec } = integrateRate(points);
     const windowSec = windowDays * 86400;
     const avgBytesPerSec = windowSec > 0 ? totalBytes / windowSec : 0;
     return { totalBytes, avgBytesPerSec, maxBytesPerSec };
-  }, [data, windowDays]);
+  }, [banditSeries, windowDays]);
 
   const hasSelectedFilters = !!(country || tier || protocol);
 

--- a/src/hooks/useBanditBandwidth.ts
+++ b/src/hooks/useBanditBandwidth.ts
@@ -61,7 +61,10 @@ function extractSeries(resp: unknown): BandwidthSeries[] {
   const results = r?.data?.result ?? [];
   for (const qr of results) {
     for (const s of qr.series ?? []) {
-      const label = s.labels?.["proxy.track"] || s.labels?.track || "total";
+      // The query always groups by proxy.track. Drop series without a track label
+      // so downstream bandit-track filtering can't silently produce an orphan "total".
+      const label = s.labels?.["proxy.track"] || s.labels?.track;
+      if (!label) continue;
       const points = (s.values ?? [])
         .map((v) => ({ ts: Number(v.timestamp) || 0, value: Number(v.value) || 0 }))
         .filter((p) => p.ts > 0)

--- a/src/hooks/useBanditBandwidth.ts
+++ b/src/hooks/useBanditBandwidth.ts
@@ -3,12 +3,11 @@ import { buildBandwidthQuery, fetchSigNozMetrics, type BandwidthFilters } from "
 import { useAuth } from "./useAuth";
 
 export interface BandwidthSeries {
-  key: string;            // "total" or track name
+  key: string;            // track name
   points: Array<{ ts: number; value: number }>;  // value in bytes/sec
 }
 
 export interface BandwidthData {
-  total: BandwidthSeries | null;
   byTrack: BandwidthSeries[];
 }
 
@@ -35,17 +34,12 @@ export function useBanditBandwidth(enabled: boolean, filters: BandwidthFilters, 
     const endMs = Date.now();
     const startMs = endMs - windowDays * 86_400_000;
     const stepSeconds = windowDays > 2 ? 3600 : 300;
+    const query = buildBandwidthQuery({ filters, groupByTrack: true, startMs, endMs, stepSeconds });
 
-    const totalQ = buildBandwidthQuery({ filters, groupByTrack: false, startMs, endMs, stepSeconds });
-    const trackQ = buildBandwidthQuery({ filters, groupByTrack: true,  startMs, endMs, stepSeconds });
-
-    Promise.all([fetchSigNozMetrics(totalQ), fetchSigNozMetrics(trackQ)])
-      .then(([totalResp, trackResp]) => {
+    fetchSigNozMetrics(query)
+      .then((resp) => {
         if (cancelled) return;
-        setData({
-          total: extractTotal(totalResp),
-          byTrack: extractSeries(trackResp),
-        });
+        setData({ byTrack: extractSeries(resp) });
       })
       .catch((err) => {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load bandwidth");
@@ -59,18 +53,6 @@ export function useBanditBandwidth(enabled: boolean, filters: BandwidthFilters, 
   }, [key, isAuthenticated]);
 
   return { data, isLoading, error };
-}
-
-function extractTotal(resp: unknown): BandwidthSeries | null {
-  const series = extractSeries(resp);
-  if (series.length === 0) return null;
-  if (series.length === 1) return { key: "total", points: series[0].points };
-  // Fallback: sum across any extra series we weren't expecting.
-  const merged = new Map<number, number>();
-  for (const s of series) {
-    for (const p of s.points) merged.set(p.ts, (merged.get(p.ts) ?? 0) + p.value);
-  }
-  return { key: "total", points: Array.from(merged.entries()).sort((a, b) => a[0] - b[0]).map(([ts, value]) => ({ ts, value })) };
 }
 
 function extractSeries(resp: unknown): BandwidthSeries[] {


### PR DESCRIPTION
Follow-up to #47. The Bandwidth tab was showing every series that \`proxy.io\` was tagged with on \`proxy.track\`, which includes tracks not under bandit management (internal/legacy).

## Changes

- Filter the chart, per-track table, and summary cards to only tracks whose names appear in the \`/v1/dashboard/tracks\` response.
- Aggregate cards are now derived from the filtered per-track series, so avg / peak / total egress always agree with the chart and table.
- Drop the separate "total" SigNoz query from \`useBanditBandwidth\` — it included non-bandit traffic and would disagree with the filtered view. One query per refresh instead of two.

## Test plan

- [x] \`tsc -b\` clean
- [ ] Manual: confirm only known tracks appear in the chart/table; confirm summary-card numbers match the stacked chart.