### PR TITLE
bandwidth: use geo.country.iso_code for country filter

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -356,7 +356,7 @@ export interface TrackMetrics {
 // BandwidthFilters drives queries on the Bandwidth tab.
 // Any field left undefined/empty means "no filter on this dimension".
 export interface BandwidthFilters {
-  country?: string;           // ISO-2, matches `country` attribute on proxy.io
+  country?: string;           // ISO-2, matches `geo.country.iso_code` attribute on proxy.io
   tier?: "pro" | "free";      // maps to client.is_pro = true|false
   protocol?: string;          // matches `proxy.protocol` resource attribute
 }
@@ -366,7 +366,8 @@ function filterItems(f: BandwidthFilters): object[] {
     { key: { key: "network.io.direction", dataType: "string", type: "tag", isColumn: false, isJSON: false }, op: "=", value: "transmit" },
   ];
   if (f.country) {
-    items.push({ key: { key: "country", dataType: "string", type: "tag", isColumn: false, isJSON: false }, op: "=", value: f.country });
+    // lantern-box emits country via semconv.GeoCountryISOCodeKey on every proxy.io data point.
+    items.push({ key: { key: "geo.country.iso_code", dataType: "string", type: "tag", isColumn: false, isJSON: false }, op: "=", value: f.country });
   }
   if (f.tier) {
     items.push({ key: { key: "client.is_pro", dataType: "bool", type: "tag", isColumn: false, isJSON: false }, op: "=", value: f.tier === "pro" });


### PR DESCRIPTION
Selecting any country on the Bandwidth tab zeroed out the chart.

## Root cause

\`lantern-box/tracker/metrics/tracker.go\` tags every \`proxy.io\` data point via \`semconv.GeoCountryISOCodeKey\`, which resolves to **\`geo.country.iso_code\`** (standard OTel). The dashboard was filtering on **\`country\`**, which is a different attribute that exists in SigNoz's catalog for \`proxy.io\` but isn't populated by lantern-box — so the filter matched nothing.

For reference, the keys lantern-box actually emits on \`proxy.io\`:

| Dimension | Key |
|---|---|
| country | \`geo.country.iso_code\` ✅ |
| tier | \`client.is_pro\` (bool) ✅ |
| protocol | \`proxy.protocol\` (resource attr on the VM) ✅ |

Tier and protocol filters were already using the right keys — this PR only fixes the country one.

## Caveat worth knowing

The country value comes from an **asynchronous** IP → country lookup worker (\`tracker/metrics/metrics.go\`). Before the worker resolves the lookup, the attribute is \`"n/a"\`. So even after this fix, the very first bytes of a new connection may be tagged \`"n/a"\` rather than an ISO code. In steady state this is a small fraction, but worth noting.

## Test plan

- [x] \`tsc -b\` clean
- [ ] Manual: pick a country in the dropdown and confirm the chart now shows non-zero bandwidth for a country known to be active (e.g. RU, IR, CN).