### PR TITLE
Bandwidth: click-to-scope track + finer time windows

### DIFF
--- a/src/components/BandwidthOverview.tsx
+++ b/src/components/BandwidthOverview.tsx
@@ -165,19 +165,24 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
     return banditSeries.filter((s) => s.key === effectiveSelectedTrack);
   }, [banditSeries, effectiveSelectedTrack]);
 
-  // Stable color + gradient id per track, keyed off the full bandit set so the
-  // per-track table (which always shows every track) never hits an undefined
-  // color lookup when only one track is selected for the chart.
+  // Stable color + gradient id per track. Keyed off the /tracks list when
+  // available so a given track keeps its color across window/filter changes
+  // (banditSeries alone is keyed off which tracks happen to have samples in
+  // the current response, so sort order — and thus color assignment — would
+  // shift when tracks drop out). Falls back to banditSeries when /tracks is
+  // unavailable.
   const { trackColor, trackGradientId } = useMemo(() => {
-    const allKeys = banditSeries.map((s) => s.key).sort();
+    const keys = tracksReady && !tracksError && tracks.length > 0
+      ? tracks.map((t) => t.name).sort()
+      : banditSeries.map((s) => s.key).sort();
     const colorMap: Record<string, string> = {};
     const gradientIdMap: Record<string, string> = {};
-    allKeys.forEach((k, i) => {
+    keys.forEach((k, i) => {
       colorMap[k] = COLORS[i % COLORS.length];
       gradientIdMap[k] = `bw-${i}`;
     });
     return { trackColor: colorMap, trackGradientId: gradientIdMap };
-  }, [banditSeries]);
+  }, [tracks, tracksReady, tracksError, banditSeries]);
 
   // Merge display series into wide-format rows for the area chart.
   const { chartData, trackKeys } = useMemo(() => {
@@ -354,7 +359,7 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
                   dataKey="ts"
                   type="number"
                   domain={["dataMin", "dataMax"]}
-                  tickFormatter={(ts: number) => new Date(ts).toLocaleDateString([], { month: "short", day: "numeric" })}
+                  tickFormatter={(ts: number) => formatAxisTick(ts, activeWindow.minutes)}
                   tick={{ fontSize: 10, fill: "#667080" }}
                   axisLine={false}
                   tickLine={false}
@@ -405,34 +410,48 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
         ) : (
           trackTotals.map((t) => {
             const isSelected = effectiveSelectedTrack === t.key;
-            const rowBg = isSelected ? "rgba(0,229,200,0.08)" : undefined;
+            const rowBg = isSelected ? "rgba(0,229,200,0.08)" : "transparent";
             const rowBorder = isSelected ? "1px solid #00e5c850" : trackRowStyle.borderBottom;
             return (
-              <div
+              <button
                 key={t.key}
-                role="button"
-                tabIndex={0}
+                type="button"
+                aria-pressed={isSelected}
                 title={isSelected ? "Click to clear selection" : "Click to scope chart and summary to this track"}
                 onClick={() => setSelectedTrack(isSelected ? null : t.key)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setSelectedTrack(isSelected ? null : t.key);
-                  }
+                style={{
+                  ...trackRowStyle,
+                  width: "100%",
+                  cursor: "pointer",
+                  background: rowBg,
+                  border: "none",
+                  borderBottom: rowBorder,
+                  textAlign: "left",
+                  font: "inherit",
+                  color: "inherit",
                 }}
-                style={{ ...trackRowStyle, cursor: "pointer", background: rowBg, borderBottom: rowBorder, outline: "none" }}
               >
                 <span style={{ width: 8, height: 8, borderRadius: "50%", background: trackColor[t.key] ?? "#667080", boxShadow: `0 0 5px ${trackColor[t.key] ?? "#667080"}60` }} />
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: isSelected ? "#00e5c8" : undefined }}>{t.key}</span>
                 <span style={{ textAlign: "right", color: "#a0a8b8" }}>{formatBytesPerSec(t.avgBytesPerSec)}</span>
                 <span style={{ textAlign: "right" }}>{formatBytes(t.totalBytes)}</span>
-              </div>
+              </button>
             );
           })
         )}
       </div>
     </div>
   );
+}
+
+// formatAxisTick picks an X-axis label granularity based on the active window.
+// Sub-day windows show HH:MM; multi-day windows show month + day.
+function formatAxisTick(ts: number, windowMinutes: number): string {
+  const d = new Date(ts);
+  if (windowMinutes < 24 * 60) {
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
 }
 
 function formatBytesPerSec(bytesPerSec: number): string {

--- a/src/components/BandwidthOverview.tsx
+++ b/src/components/BandwidthOverview.tsx
@@ -8,10 +8,15 @@ interface BandwidthOverviewProps {
   countries: DashboardCountry[];
 }
 
-const WINDOW_OPTIONS: Array<{ label: string; days: number }> = [
-  { label: "24h", days: 1 },
-  { label: "3d", days: 3 },
-  { label: "7d", days: 7 },
+// stepSeconds is chosen per window to keep point count in the 60–720 range.
+const WINDOW_OPTIONS: Array<{ label: string; minutes: number; stepSeconds: number }> = [
+  { label: "1h",  minutes: 60,    stepSeconds: 60 },
+  { label: "3h",  minutes: 180,   stepSeconds: 60 },
+  { label: "6h",  minutes: 360,   stepSeconds: 60 },
+  { label: "12h", minutes: 720,   stepSeconds: 300 },
+  { label: "1d",  minutes: 1440,  stepSeconds: 300 },
+  { label: "3d",  minutes: 4320,  stepSeconds: 3600 },
+  { label: "7d",  minutes: 10080, stepSeconds: 3600 },
 ];
 
 const COLORS = [
@@ -97,7 +102,9 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
   const [country, setCountry] = useState("");
   const [tier, setTier] = useState<"" | "pro" | "free">("");
   const [protocol, setProtocol] = useState("");
-  const [windowDays, setWindowDays] = useState(7);
+  const [windowMinutes, setWindowMinutes] = useState(10080); // 7d default
+  const [selectedTrack, setSelectedTrack] = useState<string | null>(null);
+  const activeWindow = WINDOW_OPTIONS.find((w) => w.minutes === windowMinutes) ?? WINDOW_OPTIONS[WINDOW_OPTIONS.length - 1];
   const [tracks, setTracks] = useState<DashboardTrackDetail[]>([]);
   const [tracksReady, setTracksReady] = useState(false);
   const [tracksError, setTracksError] = useState(false);
@@ -125,7 +132,7 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
     protocol: protocol || undefined,
   }), [country, tier, protocol]);
 
-  const { data, isLoading, error } = useBanditBandwidth(enabled, filters, windowDays);
+  const { data, isLoading, error } = useBanditBandwidth(enabled, filters, activeWindow.minutes, activeWindow.stepSeconds);
 
   const protocols = useMemo(() => {
     const set = new Set<string>();
@@ -144,18 +151,39 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
     return all.filter((s) => names.has(s.key));
   }, [data, tracks, tracksReady, tracksError]);
 
-  // Merge per-track time series into wide-format rows for the stacked area chart.
-  const { chartData, trackKeys, trackColor, trackGradientId } = useMemo(() => {
-    const keys = banditSeries.map((s) => s.key).sort();
+  // If the user's selected track is no longer present in the current filter
+  // window, fall back to "all" for rendering (don't mutate the state — the
+  // selection re-applies if the track reappears after a filter change).
+  const effectiveSelectedTrack = useMemo(() => {
+    if (!selectedTrack) return null;
+    return banditSeries.some((s) => s.key === selectedTrack) ? selectedTrack : null;
+  }, [banditSeries, selectedTrack]);
+
+  // Chart + summary-card scope: narrow to the selected track when one is picked.
+  const displaySeries = useMemo(() => {
+    if (!effectiveSelectedTrack) return banditSeries;
+    return banditSeries.filter((s) => s.key === effectiveSelectedTrack);
+  }, [banditSeries, effectiveSelectedTrack]);
+
+  // Stable color + gradient id per track, keyed off the full bandit set so the
+  // per-track table (which always shows every track) never hits an undefined
+  // color lookup when only one track is selected for the chart.
+  const { trackColor, trackGradientId } = useMemo(() => {
+    const allKeys = banditSeries.map((s) => s.key).sort();
     const colorMap: Record<string, string> = {};
     const gradientIdMap: Record<string, string> = {};
-    keys.forEach((k, i) => {
+    allKeys.forEach((k, i) => {
       colorMap[k] = COLORS[i % COLORS.length];
       gradientIdMap[k] = `bw-${i}`;
     });
+    return { trackColor: colorMap, trackGradientId: gradientIdMap };
+  }, [banditSeries]);
 
+  // Merge display series into wide-format rows for the area chart.
+  const { chartData, trackKeys } = useMemo(() => {
+    const keys = displaySeries.map((s) => s.key).sort();
     const byTs = new Map<number, Record<string, number>>();
-    for (const s of banditSeries) {
+    for (const s of displaySeries) {
       for (const p of s.points) {
         if (!byTs.has(p.ts)) byTs.set(p.ts, { ts: p.ts });
         byTs.get(p.ts)![s.key] = p.value;
@@ -164,11 +192,12 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
     const rows = Array.from(byTs.values())
       .map((r) => ({ ...r, ts: Number(r.ts) }))
       .sort((a, b) => a.ts - b.ts);
-    return { chartData: rows, trackKeys: keys, trackColor: colorMap, trackGradientId: gradientIdMap };
-  }, [banditSeries]);
+    return { chartData: rows, trackKeys: keys };
+  }, [displaySeries]);
 
+  // Per-track table always reflects the full set so another track can be selected.
   const trackTotals = useMemo(() => {
-    const windowSec = windowDays * 86400;
+    const windowSec = windowMinutes * 60;
     return banditSeries
       .map((s) => {
         const { totalBytes, maxBytesPerSec } = integrateRate(s.points);
@@ -176,23 +205,23 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
         return { key: s.key, totalBytes, avgBytesPerSec, maxBytesPerSec };
       })
       .sort((a, b) => b.totalBytes - a.totalBytes);
-  }, [banditSeries, windowDays]);
+  }, [banditSeries, windowMinutes]);
 
-  // Aggregate is derived from the filtered per-track series so the summary
-  // cards always agree with the chart/table.
+  // Aggregate is derived from the *displayed* series so the summary
+  // cards agree with the chart (and scope to the selected track).
   const aggregate = useMemo(() => {
     const summed = new Map<number, number>();
-    for (const s of banditSeries) {
+    for (const s of displaySeries) {
       for (const p of s.points) summed.set(p.ts, (summed.get(p.ts) ?? 0) + p.value);
     }
     const points = Array.from(summed.entries())
       .sort((a, b) => a[0] - b[0])
       .map(([ts, value]) => ({ ts, value }));
     const { totalBytes, maxBytesPerSec } = integrateRate(points);
-    const windowSec = windowDays * 86400;
+    const windowSec = windowMinutes * 60;
     const avgBytesPerSec = windowSec > 0 ? totalBytes / windowSec : 0;
     return { totalBytes, avgBytesPerSec, maxBytesPerSec };
-  }, [banditSeries, windowDays]);
+  }, [displaySeries, windowMinutes]);
 
   const hasSelectedFilters = !!(country || tier || protocol);
 
@@ -227,9 +256,9 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
         </div>
         <div style={{ display: "flex", flexDirection: "column", minWidth: 120 }}>
           <span style={filterLabel}>Window</span>
-          <select style={filterSelect} value={windowDays} onChange={(e) => setWindowDays(Number(e.target.value))}>
+          <select style={filterSelect} value={windowMinutes} onChange={(e) => setWindowMinutes(Number(e.target.value))}>
             {WINDOW_OPTIONS.map((w) => (
-              <option key={w.days} value={w.days}>{w.label}</option>
+              <option key={w.minutes} value={w.minutes}>{w.label}</option>
             ))}
           </select>
         </div>
@@ -286,11 +315,18 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
 
       <div style={chartCard}>
         <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: "0.5rem" }}>
-          <div style={{ fontFamily: "var(--font-sans)", fontSize: "0.75rem", fontWeight: 600, color: "#d0d8e4" }}>
-            Bandwidth by track
+          <div style={{ display: "flex", alignItems: "baseline", gap: "0.5rem" }}>
+            <div style={{ fontFamily: "var(--font-sans)", fontSize: "0.75rem", fontWeight: 600, color: "#d0d8e4" }}>
+              {effectiveSelectedTrack ? "Bandwidth" : "Bandwidth by track"}
+            </div>
+            {effectiveSelectedTrack && (
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "#00e5c8" }}>
+                — {effectiveSelectedTrack}
+              </span>
+            )}
           </div>
           <div style={{ fontFamily: "var(--font-mono)", fontSize: "0.55rem", color: "#667080" }}>
-            {WINDOW_OPTIONS.find((w) => w.days === windowDays)?.label} · stacked · bytes/sec
+            {activeWindow.label} · {effectiveSelectedTrack ? "single track" : "stacked"} · bytes/sec
           </div>
         </div>
         <div style={{ height: 320 }}>
@@ -367,14 +403,32 @@ export default function BandwidthOverview({ enabled, countries }: BandwidthOverv
             No per-track data
           </div>
         ) : (
-          trackTotals.map((t) => (
-            <div key={t.key} style={trackRowStyle}>
-              <span style={{ width: 8, height: 8, borderRadius: "50%", background: trackColor[t.key] ?? "#667080", boxShadow: `0 0 5px ${trackColor[t.key] ?? "#667080"}60` }} />
-              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{t.key}</span>
-              <span style={{ textAlign: "right", color: "#a0a8b8" }}>{formatBytesPerSec(t.avgBytesPerSec)}</span>
-              <span style={{ textAlign: "right" }}>{formatBytes(t.totalBytes)}</span>
-            </div>
-          ))
+          trackTotals.map((t) => {
+            const isSelected = effectiveSelectedTrack === t.key;
+            const rowBg = isSelected ? "rgba(0,229,200,0.08)" : undefined;
+            const rowBorder = isSelected ? "1px solid #00e5c850" : trackRowStyle.borderBottom;
+            return (
+              <div
+                key={t.key}
+                role="button"
+                tabIndex={0}
+                title={isSelected ? "Click to clear selection" : "Click to scope chart and summary to this track"}
+                onClick={() => setSelectedTrack(isSelected ? null : t.key)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setSelectedTrack(isSelected ? null : t.key);
+                  }
+                }}
+                style={{ ...trackRowStyle, cursor: "pointer", background: rowBg, borderBottom: rowBorder, outline: "none" }}
+              >
+                <span style={{ width: 8, height: 8, borderRadius: "50%", background: trackColor[t.key] ?? "#667080", boxShadow: `0 0 5px ${trackColor[t.key] ?? "#667080"}60` }} />
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: isSelected ? "#00e5c8" : undefined }}>{t.key}</span>
+                <span style={{ textAlign: "right", color: "#a0a8b8" }}>{formatBytesPerSec(t.avgBytesPerSec)}</span>
+                <span style={{ textAlign: "right" }}>{formatBytes(t.totalBytes)}</span>
+              </div>
+            );
+          })
         )}
       </div>
     </div>

--- a/src/hooks/useBanditBandwidth.ts
+++ b/src/hooks/useBanditBandwidth.ts
@@ -17,13 +17,18 @@ interface UseBanditBandwidthResult {
   error: string | null;
 }
 
-export function useBanditBandwidth(enabled: boolean, filters: BandwidthFilters, windowDays: number): UseBanditBandwidthResult {
+export function useBanditBandwidth(
+  enabled: boolean,
+  filters: BandwidthFilters,
+  windowMinutes: number,
+  stepSeconds: number,
+): UseBanditBandwidthResult {
   const { isAuthenticated } = useAuth();
   const [data, setData] = useState<BandwidthData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const key = `${enabled}|${filters.country ?? ""}|${filters.tier ?? ""}|${filters.protocol ?? ""}|${windowDays}`;
+  const key = `${enabled}|${filters.country ?? ""}|${filters.tier ?? ""}|${filters.protocol ?? ""}|${windowMinutes}|${stepSeconds}`;
 
   useEffect(() => {
     if (!enabled || !isAuthenticated) return;
@@ -32,8 +37,7 @@ export function useBanditBandwidth(enabled: boolean, filters: BandwidthFilters, 
     setError(null);
 
     const endMs = Date.now();
-    const startMs = endMs - windowDays * 86_400_000;
-    const stepSeconds = windowDays > 2 ? 3600 : 300;
+    const startMs = endMs - windowMinutes * 60_000;
     const query = buildBandwidthQuery({ filters, groupByTrack: true, startMs, endMs, stepSeconds });
 
     fetchSigNozMetrics(query)


### PR DESCRIPTION
Two small UX additions on top of the Bandwidth tab.

## Click-to-scope a track

Click any row in the per-track table to narrow the chart and the four summary cards (avg / peak / total / track count) to just that track. Click the same row again to clear.

- Highlighted row + \`— <track>\` caption on the chart title make the scoped state obvious.
- Colors are stable across all tracks (keyed off the full bandit set), so the selected track keeps its color whether rendered alone or stacked.
- If the underlying filters change and the selected track no longer has samples in the current window, the chart silently falls back to "all tracks" — no state mutation, no flicker. If it comes back, the selection re-applies.

## More time windows

Replaces 24h/3d/7d with **1h, 3h, 6h, 12h, 1d, 3d, 7d**. Each window has a step interval chosen to keep the sample count in the 60–720 range:

| Window | Step |
|---|---|
| 1h / 3h / 6h | 1m |
| 12h / 1d | 5m |
| 3d / 7d | 1h |

The hook signature changed from \`(enabled, filters, windowDays)\` to \`(enabled, filters, windowMinutes, stepSeconds)\`.

## Test plan

- [x] \`tsc -b\` clean
- [x] lint clean on changed files
- [x] \`vite build\` clean
- [ ] Manual: open tab, click a track, confirm chart + summary rescope and the row highlights; click again, confirm it clears
- [ ] Manual: try each window option and confirm chart re-renders with appropriate granularity; tooltip timestamps should be minute-precise for <=6h