### PR TITLE
add Releases tab: bandit VPS release-skew panel

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -284,6 +284,37 @@ export function fetchTracks(): Promise<DashboardTracksResponse> {
   return apiFetch("/tracks");
 }
 
+// ── Release skew (bandit VPS central-update orchestration) ──
+// Mirrors dashboardReleaseSkewResponse in cmd/api/dashboard_handler.go.
+// Powered by GetBanditVPSImageSkew + ListBanditVPSImageTargets.
+
+export interface ReleaseSkewBucket {
+  targetTag: string;
+  currentTag: string;
+  routeCount: number;
+  oldestCreated: string;
+  matched: boolean;
+}
+
+export interface ReleaseSkewTrack {
+  trackId: number;
+  trackName: string;
+  targetTag?: string; // per-track override; empty means "inherit fleet default"
+  buckets: ReleaseSkewBucket[];
+  totalRunning: number;
+  lagOldest?: string;
+}
+
+export interface ReleaseSkewResponse {
+  tracks: ReleaseSkewTrack[];
+  fleetDefault: string;
+  autoreplaceActive: boolean;
+}
+
+export function fetchReleaseSkew(): Promise<ReleaseSkewResponse> {
+  return apiFetch("/release-skew");
+}
+
 // ── SigNoz metrics proxy ──
 
 // Posts a SigNoz v5 builder query to the API's /proxy/metrics endpoint.

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ import VPSOverview from "./VPSOverview";
 import BanditArmsOverview, { BanditHowItWorks } from "./BanditArmsOverview";
 import TracksOverview from "./TracksOverview";
 import BandwidthOverview from "./BandwidthOverview";
+import ReleaseSkewOverview from "./ReleaseSkewOverview";
 import AISummary from "./AISummary";
 import AdminPanel from "./AdminPanel";
 import type { GlobalStats } from "../data/mock";
@@ -35,18 +36,19 @@ function LanternLogo() {
 export default function Dashboard() {
   const { isAuthenticated, user, logout, token } = useAuth();
   const { globalStats, dataCenters, activityEvents, trafficFlows, isLive, blockedRoutes, demoMode, toggleDemoMode } = useLiveData();
-  const [activeTab, setActiveTab] = useState<'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'bandwidth' | 'proxy' | 'admin'>(() => {
+  const [activeTab, setActiveTab] = useState<'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'bandwidth' | 'releases' | 'proxy' | 'admin'>(() => {
     const hash = window.location.hash;
     if (hash === '#overview') return 'overview';
     if (hash === '#vps') return 'vps';
     if (hash === '#arms') return 'arms';
     if (hash === '#tracks') return 'tracks';
     if (hash === '#bandwidth') return 'bandwidth';
+    if (hash === '#releases') return 'releases';
     if (hash === '#proxy') return 'proxy';
     if (hash === '#admin') return 'admin';
     return 'map';
   });
-  const switchTab = useCallback((tab: 'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'bandwidth' | 'proxy' | 'admin') => {
+  const switchTab = useCallback((tab: 'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'bandwidth' | 'releases' | 'proxy' | 'admin') => {
     setActiveTab(tab);
     window.location.hash = tab === 'map' ? '' : `#${tab}`;
   }, []);
@@ -123,7 +125,7 @@ export default function Dashboard() {
           </div>
         </div>
         <div style={{ display: "flex", gap: "0.25rem", marginLeft: "1.5rem" }}>
-          {(["map", "overview", "vps", "arms", "tracks", "bandwidth", "proxy", "admin"] as const).map((tab) => (
+          {(["map", "overview", "vps", "arms", "tracks", "bandwidth", "releases", "proxy", "admin"] as const).map((tab) => (
             <div
               key={tab}
               onClick={() => switchTab(tab)}
@@ -141,7 +143,7 @@ export default function Dashboard() {
                 letterSpacing: "0.05em",
               }}
             >
-              {{ map: "Map", overview: "Overview", vps: "VPS Fleet", arms: "Bandit Arms", tracks: "Tracks", bandwidth: "Bandwidth", proxy: "Share Proxy", admin: "Admin" }[tab]}
+              {{ map: "Map", overview: "Overview", vps: "VPS Fleet", arms: "Bandit Arms", tracks: "Tracks", bandwidth: "Bandwidth", releases: "Releases", proxy: "Share Proxy", admin: "Admin" }[tab]}
             </div>
           ))}
         </div>
@@ -231,6 +233,8 @@ export default function Dashboard() {
           <TracksOverview />
         ) : activeTab === "bandwidth" ? (
           <BandwidthOverview enabled={activeTab === "bandwidth"} countries={globalStats.countries} />
+        ) : activeTab === "releases" ? (
+          <ReleaseSkewOverview />
         ) : activeTab === "proxy" ? (
           <div style={{ flex: 1, padding: "1rem" }}>
             <ProxyWidget {...proxy} />

--- a/src/components/ReleaseSkewOverview.tsx
+++ b/src/components/ReleaseSkewOverview.tsx
@@ -1,0 +1,261 @@
+import { useMemo, type CSSProperties } from "react";
+import { useReleaseSkew } from "../hooks/useReleaseSkew";
+
+// ReleaseSkewOverview renders the current convergence state of the
+// bandit VPS fleet: per track, a stacked bar showing how many running
+// routes sit at each (target, current) release-tag pair, with a single
+// fleet-wide target at the top and a "lag" timestamp per mismatched
+// track. Powered by /dashboard/release-skew (GetBanditVPSImageSkew).
+//
+// Design doc: lantern-cloud/docs/design/central-vps-updates.md.
+export default function ReleaseSkewOverview() {
+  const { data, isLoading, hasLoaded, error } = useReleaseSkew(true);
+
+  // Summary numbers across the whole fleet.
+  const summary = useMemo(() => {
+    if (!data) return { running: 0, converged: 0, lagging: 0, tracks: 0 };
+    let running = 0;
+    let converged = 0;
+    let lagging = 0;
+    for (const t of data.tracks) {
+      running += t.totalRunning;
+      for (const b of t.buckets) {
+        if (b.matched) converged += b.routeCount;
+        else lagging += b.routeCount;
+      }
+    }
+    return { running, converged, lagging, tracks: data.tracks.length };
+  }, [data]);
+
+  if (isLoading && !hasLoaded) {
+    return <div style={messageStyle}>Loading release skew…</div>;
+  }
+  if (error && !hasLoaded) {
+    return <div style={{ ...messageStyle, color: "#e06060" }}>{error}</div>;
+  }
+  if (!data) {
+    return <div style={messageStyle}>No data</div>;
+  }
+
+  const fleetDefault = data.fleetDefault || "(unset)";
+  const orchestrationOn = data.autoreplaceActive;
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.75rem", overflowY: "auto", padding: "0.75rem" }}>
+      {/* Summary cards */}
+      <div style={{ display: "flex", gap: "0.65rem", flexWrap: "wrap" }}>
+        <div style={card}>
+          <div style={cardLabel}>Fleet target</div>
+          <div style={{ ...cardValue, color: orchestrationOn ? "#00e5c8" : "#8890a0" }}>{fleetDefault}</div>
+          <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap", marginTop: "0.35rem" }}>
+            <span style={{ ...chipStyle, color: orchestrationOn ? "#a0c8a0" : "#667080" }}>
+              {orchestrationOn ? "autoreplace ON" : "autoreplace OFF"}
+            </span>
+          </div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Running routes</div>
+          <div style={{ ...cardValue, color: "#64b4ff" }}>{summary.running}</div>
+          <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap", marginTop: "0.35rem" }}>
+            <span style={chipStyle}>{summary.tracks} tracks</span>
+          </div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Converged</div>
+          <div style={{ ...cardValue, color: "#a0c8a0" }}>{summary.converged}</div>
+          <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap", marginTop: "0.35rem" }}>
+            <span style={{ ...chipStyle, color: "#a0c8a0" }}>
+              {summary.running > 0 ? `${Math.round((summary.converged / summary.running) * 100)}% of fleet` : "—"}
+            </span>
+          </div>
+        </div>
+        <div style={card}>
+          <div style={cardLabel}>Lagging</div>
+          <div style={{ ...cardValue, color: summary.lagging > 0 ? "#f0a030" : "#667080" }}>{summary.lagging}</div>
+          <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap", marginTop: "0.35rem" }}>
+            <span style={chipStyle}>target ≠ current</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Per-track rows */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+        {data.tracks.map((t) => (
+          <TrackRow
+            key={t.trackId}
+            trackName={t.trackName}
+            targetOverride={t.targetTag}
+            fleetDefault={fleetDefault}
+            totalRunning={t.totalRunning}
+            lagOldest={t.lagOldest}
+            buckets={t.buckets}
+          />
+        ))}
+        {data.tracks.length === 0 && (
+          <div style={messageStyle}>No running bandit VPS routes.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TrackRow({
+  trackName,
+  targetOverride,
+  fleetDefault,
+  totalRunning,
+  lagOldest,
+  buckets,
+}: {
+  trackName: string;
+  targetOverride?: string;
+  fleetDefault: string;
+  totalRunning: number;
+  lagOldest?: string;
+  buckets: Array<{ targetTag: string; currentTag: string; routeCount: number; matched: boolean }>;
+}) {
+  const effectiveTarget = targetOverride || fleetDefault;
+  const lagAge = lagOldest ? formatAge(lagOldest) : null;
+
+  return (
+    <div style={rowStyle}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: "0.6rem", marginBottom: "0.35rem" }}>
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.85rem", fontWeight: 600, color: "#e0e5ec" }}>
+          {trackName}
+        </span>
+        <span style={{ ...chipStyle, color: "#64b4ff" }}>target {effectiveTarget}</span>
+        {targetOverride && (
+          <span style={{ ...chipStyle, color: "#f0a030" }}>per-track override</span>
+        )}
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "#667080" }}>
+          {totalRunning} running
+        </span>
+        {lagAge && (
+          <span style={{ ...chipStyle, color: "#e06060", marginLeft: "auto" }}>
+            oldest lag {lagAge}
+          </span>
+        )}
+      </div>
+
+      {/* Stacked bar */}
+      <div style={{ display: "flex", height: 14, borderRadius: 3, overflow: "hidden", background: "#0a0d12" }}>
+        {buckets.map((b, i) => {
+          const pct = totalRunning > 0 ? (b.routeCount / totalRunning) * 100 : 0;
+          const color = b.matched ? "#a0c8a0" : "#f0a030";
+          return (
+            <div
+              key={i}
+              title={bucketTooltip(b)}
+              style={{
+                width: `${pct}%`,
+                background: color,
+                opacity: b.matched ? 0.9 : 0.75,
+                borderRight: i < buckets.length - 1 ? "1px solid #0a0d12" : "none",
+              }}
+            />
+          );
+        })}
+      </div>
+
+      {/* Per-bucket legend */}
+      <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap", marginTop: "0.35rem" }}>
+        {buckets.map((b, i) => (
+          <span
+            key={i}
+            style={{
+              ...chipStyle,
+              color: b.matched ? "#a0c8a0" : "#f0a030",
+              background: "#ffffff05",
+            }}
+          >
+            {bucketLabel(b)} · {b.routeCount}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function bucketLabel(b: { targetTag: string; currentTag: string; matched: boolean }): string {
+  const t = b.targetTag || "—";
+  const c = b.currentTag || "—";
+  if (b.matched) return `✓ ${c}`;
+  return `${c} → ${t}`;
+}
+
+function bucketTooltip(b: { targetTag: string; currentTag: string; routeCount: number; matched: boolean; oldestCreated?: string }): string {
+  const parts = [
+    `current: ${b.currentTag || "(unset)"}`,
+    `target: ${b.targetTag || "(unset)"}`,
+    `routes: ${b.routeCount}`,
+    b.matched ? "converged" : "release drift",
+  ];
+  return parts.join("\n");
+}
+
+function formatAge(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!isFinite(then)) return iso;
+  const deltaMs = Date.now() - then;
+  const minutes = Math.floor(deltaMs / 60000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+// ── styles (match TracksOverview.tsx so the tab feels consistent) ──
+
+const card: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  padding: "1rem 1.1rem",
+  minWidth: 0,
+  flex: "1 1 0",
+};
+
+const cardLabel: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.6rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "#8890a0",
+  marginBottom: "0.3rem",
+};
+
+const cardValue: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "1.6rem",
+  fontWeight: 600,
+  lineHeight: 1.15,
+};
+
+const chipStyle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.5rem",
+  padding: "0.1rem 0.4rem",
+  borderRadius: 3,
+  background: "#ffffff08",
+  color: "#8890a0",
+  whiteSpace: "nowrap",
+  display: "inline-block",
+};
+
+const rowStyle: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  padding: "0.75rem 1rem",
+};
+
+const messageStyle: CSSProperties = {
+  flex: 1,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: 300,
+  color: "#667080",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.75rem",
+};

--- a/src/hooks/useReleaseSkew.ts
+++ b/src/hooks/useReleaseSkew.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import { fetchReleaseSkew, type ReleaseSkewResponse } from "../api/client";
+import { useAuth } from "./useAuth";
+
+// useReleaseSkew polls the /release-skew endpoint on a 60s cadence while
+// the consumer is enabled. Preserves the last successful payload across
+// refreshes (isFirst/hasLoaded) so the UI doesn't blank out between
+// polls — same pattern as useVPSData.
+export function useReleaseSkew(enabled: boolean) {
+  const { isAuthenticated } = useAuth();
+  const [data, setData] = useState<ReleaseSkewResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !isAuthenticated) return;
+    let cancelled = false;
+    let isFirst = true;
+
+    const refresh = async () => {
+      if (isFirst) setIsLoading(true);
+      try {
+        const resp = await fetchReleaseSkew();
+        if (cancelled) return;
+        setData(resp);
+        setError(null);
+        setHasLoaded(true);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load release skew");
+      } finally {
+        if (!cancelled && isFirst) setIsLoading(false);
+        isFirst = false;
+      }
+    };
+
+    refresh();
+    const interval = setInterval(refresh, 60000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [enabled, isAuthenticated]);
+
+  return { data, isLoading, hasLoaded, error };
+}


### PR DESCRIPTION
## Summary

Adds a **Releases** tab to the dashboard that visualizes the bandit VPS fleet's convergence state under the new central-update orchestration system.

- **Fleet target** card: the value of `bandit_vps_default_release_tag` + whether `bandit_vps_autoreplace_enabled` is on.
- **Running / Converged / Lagging** counters across the whole fleet.
- **Per-track rows**: stacked bar where each segment is a `(current_tag, target_tag)` bucket, green if matched (converged) and amber if mismatched. Each track shows its per-track override (if any) vs. the fleet default, plus an **oldest lag** badge when there's any lagging bucket — that's the "rollout stopped" signal from the design doc.

Paired with lantern-cloud PR #2630 which adds the backing `/v1/dashboard/release-skew` endpoint and the whole central-orchestration stack (hot-swap + autoreplace workers).

## Testing

- [ ] Merge lantern-cloud PR first
- [ ] Visit `#releases` tab with no release-skew data (fresh deploy, `bandit_vps_default_release_tag` unset) — should show "autoreplace OFF" chip and `(unset)` target, all routes in a single unmatched bucket
- [ ] Set `bandit_vps_default_release_tag` to the current fleet version — converged count should climb as the hot-swap worker populates `current_release_tag` per route
- [ ] Bump the target; watch the "lagging" count rise, then fall as hot-swap converges. Lag-oldest timestamp should advance (if it doesn't, workers are stuck)

## Notes

Style matches TracksOverview for consistency. No new dependencies. Same `useVPSData`-style polling pattern (60s refresh, preserves last payload across refreshes to avoid UI blanking).