### PR TITLE
admin: prod/staging API environment toggle

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -13,41 +13,52 @@
 // so a post-toggle reload hits the new endpoint.
 export const API_ENV_STORAGE_KEY = "lantern-dashboard-api-env";
 
-export type ApiEnv = "prod" | "staging";
+// "custom" is reported when VITE_API_URL is set to a non-canonical URL
+// (typically a local-dev tunnel) and no operator override is stored —
+// makes the badge say "custom" instead of lying with "prod" while
+// actually talking to something else.
+export type ApiEnv = "prod" | "staging" | "custom";
 
-const API_URLS: Record<ApiEnv, string> = {
+const API_URLS: Record<Exclude<ApiEnv, "custom">, string> = {
   prod: "https://api.iantem.io",
   staging: "https://api.staging.iantem.io",
 };
 
-export function getApiEnv(): ApiEnv {
+function getStoredApiEnv(): Exclude<ApiEnv, "custom"> | null {
   try {
     const v = localStorage.getItem(API_ENV_STORAGE_KEY);
     if (v === "prod" || v === "staging") return v;
   } catch {
     // localStorage unavailable (private tab, etc.) — fall through.
   }
+  return null;
+}
+
+export function getApiEnv(): ApiEnv {
+  const stored = getStoredApiEnv();
+  if (stored) return stored;
+
   // Build-time VITE_API_URL takes effect only when no explicit override:
   // lets local dev point at anything (including a tunnel) without the
   // toggle UI fighting the build config.
   const built = import.meta.env.VITE_API_URL;
   if (built === API_URLS.staging) return "staging";
+  if (built === API_URLS.prod) return "prod";
+  if (built) return "custom";
   return "prod";
 }
 
 export function getApiUrl(): string {
   // If a build-time URL was set AND no explicit override is stored,
   // honor it (supports local dev against a non-canonical tunnel).
-  try {
-    const stored = localStorage.getItem(API_ENV_STORAGE_KEY);
-    if (stored !== "prod" && stored !== "staging") {
-      const built = import.meta.env.VITE_API_URL;
-      if (built) return built;
-    }
-  } catch {
-    // fall through
+  const stored = getStoredApiEnv();
+  if (!stored) {
+    const built = import.meta.env.VITE_API_URL;
+    if (built) return built;
   }
-  return API_URLS[getApiEnv()];
+  const env = getApiEnv();
+  if (env === "staging") return API_URLS.staging;
+  return API_URLS.prod;
 }
 
 // setApiEnv writes the operator's choice to localStorage and reloads
@@ -491,7 +502,7 @@ export interface BanditResetResponse {
 }
 
 export async function resetBanditData(): Promise<BanditResetResponse> {
-  const url = `${API_URL}/v1/dashboard/bandit/reset`;
+  const url = `${getApiUrl()}/v1/dashboard/bandit/reset`;
   const headers: Record<string, string> = {};
   if (authToken) headers.Authorization = `Bearer ${authToken}`;
   const res = await fetch(url, { method: "POST", headers });
@@ -504,7 +515,7 @@ export async function resetBanditData(): Promise<BanditResetResponse> {
 }
 
 export function getStreamURL(): string {
-  const url = new URL(`${API_URL}/v1/dashboard/stream`);
+  const url = new URL(`${getApiUrl()}/v1/dashboard/stream`);
   if (authToken) url.searchParams.set("token", authToken);
   return url.toString();
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,70 @@
-const API_URL = import.meta.env.VITE_API_URL || "https://api.iantem.io";
+// Environment selection
+//
+// Two canonical environments for the lantern-cloud API:
+//   - prod:    https://api.iantem.io
+//   - staging: https://api.staging.iantem.io
+//
+// An operator can override via the Admin panel (see setApiEnv below);
+// the choice persists in localStorage per-browser. If nothing is set,
+// we fall back to VITE_API_URL (build-time default for local dev) and
+// finally to prod.
+//
+// Callers should NEVER capture API_URL at import time — use getApiUrl()
+// so a post-toggle reload hits the new endpoint.
+export const API_ENV_STORAGE_KEY = "lantern-dashboard-api-env";
+
+export type ApiEnv = "prod" | "staging";
+
+const API_URLS: Record<ApiEnv, string> = {
+  prod: "https://api.iantem.io",
+  staging: "https://api.staging.iantem.io",
+};
+
+export function getApiEnv(): ApiEnv {
+  try {
+    const v = localStorage.getItem(API_ENV_STORAGE_KEY);
+    if (v === "prod" || v === "staging") return v;
+  } catch {
+    // localStorage unavailable (private tab, etc.) — fall through.
+  }
+  // Build-time VITE_API_URL takes effect only when no explicit override:
+  // lets local dev point at anything (including a tunnel) without the
+  // toggle UI fighting the build config.
+  const built = import.meta.env.VITE_API_URL;
+  if (built === API_URLS.staging) return "staging";
+  return "prod";
+}
+
+export function getApiUrl(): string {
+  // If a build-time URL was set AND no explicit override is stored,
+  // honor it (supports local dev against a non-canonical tunnel).
+  try {
+    const stored = localStorage.getItem(API_ENV_STORAGE_KEY);
+    if (stored !== "prod" && stored !== "staging") {
+      const built = import.meta.env.VITE_API_URL;
+      if (built) return built;
+    }
+  } catch {
+    // fall through
+  }
+  return API_URLS[getApiEnv()];
+}
+
+// setApiEnv writes the operator's choice to localStorage and reloads
+// the page. Reload is the simplest way to propagate the change: every
+// in-flight hook tears down, and the next render reads the new URL
+// via getApiUrl(). Anything cached in module-scope closures (e.g.
+// auth handlers that snapshotted the URL) also resets.
+export function setApiEnv(env: ApiEnv): void {
+  try {
+    localStorage.setItem(API_ENV_STORAGE_KEY, env);
+  } catch {
+    // If localStorage is unavailable we can't persist — but still
+    // reload, since a transient override via setting window.location
+    // would be confusing.
+  }
+  window.location.reload();
+}
 
 let authToken: string | null = null;
 let onAuthExpired: (() => Promise<string | null>) | null = null;
@@ -12,7 +78,7 @@ export function setOnAuthExpired(handler: () => Promise<string | null>) {
 }
 
 async function apiFetch<T>(path: string, params?: Record<string, string>): Promise<T> {
-  const url = new URL(`${API_URL}/v1/dashboard${path}`);
+  const url = new URL(`${getApiUrl()}/v1/dashboard${path}`);
   if (params) {
     Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
   }
@@ -289,7 +355,7 @@ export function fetchTracks(): Promise<DashboardTracksResponse> {
 // Posts a SigNoz v5 builder query to the API's /proxy/metrics endpoint.
 // Returns the raw SigNoz response (caller must parse the result structure).
 export async function fetchSigNozMetrics(body: object): Promise<any> {
-  const url = `${API_URL}/v1/dashboard/metrics`;
+  const url = `${getApiUrl()}/v1/dashboard/metrics`;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (authToken) headers.Authorization = `Bearer ${authToken}`;
   const res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });

--- a/src/components/AISummary.tsx
+++ b/src/components/AISummary.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 
-const API_URL = import.meta.env.VITE_API_URL || "https://api.iantem.io";
+import { getApiUrl } from "../api/client";
 
 interface SummaryData {
   text: string;
@@ -50,7 +50,7 @@ export default function AISummary({ authToken }: { authToken: string | null }) {
     if (authToken) headers.Authorization = `Bearer ${authToken}`;
 
     try {
-      const res = await fetch(`${API_URL}/v1/dashboard/ai-summary`, { headers });
+      const res = await fetch(`${getApiUrl()}/v1/dashboard/ai-summary`, { headers });
 
       if (res.ok) {
         const data = await res.json();
@@ -82,7 +82,7 @@ export default function AISummary({ authToken }: { authToken: string | null }) {
     setState("streaming");
     setSummary({ text: "", generatedAt: "", model: "", cached: false });
 
-    const url = `${API_URL}/v1/dashboard/ai-summary/stream`;
+    const url = `${getApiUrl()}/v1/dashboard/ai-summary/stream`;
     const es = new EventSource(`${url}?token=${authToken}`);
 
     es.addEventListener("summary", (e) => {

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,11 +1,18 @@
 import { useState } from "react";
-import { resetBanditData, type BanditResetResponse } from "../api/client";
+import {
+  resetBanditData,
+  type BanditResetResponse,
+  getApiEnv,
+  setApiEnv,
+  type ApiEnv,
+} from "../api/client";
 
 export default function AdminPanel() {
   const [resetting, setResetting] = useState(false);
   const [result, setResult] = useState<BanditResetResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const currentEnv = getApiEnv();
 
   const handleReset = async () => {
     setConfirmOpen(false);
@@ -34,6 +41,55 @@ export default function AdminPanel() {
       }}>
         Admin
       </h2>
+
+      {/* API environment */}
+      <div style={{
+        background: "var(--bg-secondary)",
+        border: "1px solid #ffffff0a",
+        borderRadius: "var(--radius-md)",
+        padding: "1.25rem",
+        marginBottom: "1rem",
+      }}>
+        <div style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.7rem",
+          color: "var(--text-primary)",
+          marginBottom: "0.5rem",
+          fontWeight: 600,
+        }}>
+          API Environment
+        </div>
+        <div style={{
+          fontSize: "0.65rem",
+          color: "var(--text-muted)",
+          lineHeight: 1.6,
+          marginBottom: "1rem",
+        }}>
+          Switch which lantern-cloud API the dashboard talks to. Stored per-browser
+          in localStorage; selecting a value reloads the page so all hooks and
+          caches pick up the change.
+          <br />
+          <span style={{ color: "var(--text-secondary)" }}>
+            prod: <code>api.iantem.io</code> &middot; staging: <code>api.staging.iantem.io</code>
+          </span>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          {(["prod", "staging"] as const).map((env) => (
+            <EnvButton key={env} env={env} active={currentEnv === env} />
+          ))}
+          <span style={{
+            marginLeft: "0.75rem",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.55rem",
+            color: "var(--text-muted)",
+          }}>
+            current: <span style={{
+              color: currentEnv === "prod" ? "var(--accent-primary)" : "#f0a030",
+            }}>{currentEnv}</span>
+          </span>
+        </div>
+      </div>
 
       {/* Bandit Reset */}
       <div style={{
@@ -162,5 +218,33 @@ export default function AdminPanel() {
         )}
       </div>
     </div>
+  );
+}
+
+function EnvButton({ env, active }: { env: ApiEnv; active: boolean }) {
+  const activeBg = env === "prod" ? "var(--accent-primary-dim)" : "#f0a03020";
+  const activeColor = env === "prod" ? "var(--accent-primary)" : "#f0a030";
+  const activeBorder = env === "prod" ? "#00e5c830" : "#f0a03040";
+  return (
+    <button
+      onClick={() => {
+        if (!active) setApiEnv(env);
+      }}
+      disabled={active}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6rem",
+        padding: "0.4rem 1rem",
+        borderRadius: "var(--radius-sm)",
+        background: active ? activeBg : "#ffffff08",
+        color: active ? activeColor : "var(--text-muted)",
+        border: `1px solid ${active ? activeBorder : "#ffffff10"}`,
+        cursor: active ? "default" : "pointer",
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+      }}
+    >
+      {env}
+    </button>
   );
 }

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -84,11 +84,22 @@ export default function AdminPanel() {
             fontSize: "0.55rem",
             color: "var(--text-muted)",
           }}>
-            current: <span style={{
-              color: currentEnv === "prod" ? "var(--accent-primary)" : "#f0a030",
-            }}>{currentEnv}</span>
+            current: <span style={{ color: envColor(currentEnv) }}>{currentEnv}</span>
           </span>
         </div>
+        {currentEnv === "custom" && (
+          <div style={{
+            marginTop: "0.75rem",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.55rem",
+            color: "#ff4060",
+            lineHeight: 1.5,
+          }}>
+            Requests are going to a non-canonical URL from VITE_API_URL
+            (typically a local-dev tunnel). Click prod or staging above
+            to override with a canonical endpoint.
+          </div>
+        )}
       </div>
 
       {/* Bandit Reset */}
@@ -221,9 +232,9 @@ export default function AdminPanel() {
   );
 }
 
-function EnvButton({ env, active }: { env: ApiEnv; active: boolean }) {
+function EnvButton({ env, active }: { env: "prod" | "staging"; active: boolean }) {
   const activeBg = env === "prod" ? "var(--accent-primary-dim)" : "#f0a03020";
-  const activeColor = env === "prod" ? "var(--accent-primary)" : "#f0a030";
+  const activeColor = envColor(env);
   const activeBorder = env === "prod" ? "#00e5c830" : "#f0a03040";
   return (
     <button
@@ -247,4 +258,15 @@ function EnvButton({ env, active }: { env: ApiEnv; active: boolean }) {
       {env}
     </button>
   );
+}
+
+function envColor(env: ApiEnv): string {
+  switch (env) {
+    case "prod":
+      return "var(--accent-primary)";
+    case "staging":
+      return "#f0a030";
+    case "custom":
+      return "#ff4060";
+  }
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -14,7 +14,39 @@ import TracksOverview from "./TracksOverview";
 import BandwidthOverview from "./BandwidthOverview";
 import AISummary from "./AISummary";
 import AdminPanel from "./AdminPanel";
+import { getApiEnv } from "../api/client";
 import type { GlobalStats } from "../data/mock";
+
+// ApiEnvBadge makes the current API environment impossible to miss.
+// Staging routes 1x1 pixel of your attention when you'd otherwise think
+// you're looking at prod. Clicking jumps to the Admin tab where the
+// actual toggle lives.
+function ApiEnvBadge() {
+  const env = getApiEnv();
+  const isStaging = env === "staging";
+  return (
+    <div
+      onClick={() => { window.location.hash = "#admin"; window.location.reload(); }}
+      title="Click to open Admin panel and switch environments"
+      style={{
+        marginLeft: "0.75rem",
+        padding: "0.15rem 0.5rem",
+        borderRadius: "var(--radius-sm)",
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.55rem",
+        textTransform: "uppercase",
+        letterSpacing: "0.08em",
+        cursor: "pointer",
+        userSelect: "none" as const,
+        color: isStaging ? "#f0a030" : "var(--accent-primary)",
+        background: isStaging ? "#f0a03015" : "var(--accent-primary-dim)",
+        border: `1px solid ${isStaging ? "#f0a03040" : "#00e5c830"}`,
+      }}
+    >
+      {env}
+    </div>
+  );
+}
 
 function LanternLogo() {
   return (
@@ -121,6 +153,7 @@ export default function Dashboard() {
             <div className="header-title">Lantern</div>
             <div className="header-subtitle">Bandit Dashboard</div>
           </div>
+          <ApiEnvBadge />
         </div>
         <div style={{ display: "flex", gap: "0.25rem", marginLeft: "1.5rem" }}>
           {(["map", "overview", "vps", "arms", "tracks", "bandwidth", "proxy", "admin"] as const).map((tab) => (

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -20,14 +20,28 @@ import type { GlobalStats } from "../data/mock";
 // ApiEnvBadge makes the current API environment impossible to miss.
 // Staging routes 1x1 pixel of your attention when you'd otherwise think
 // you're looking at prod. Clicking jumps to the Admin tab where the
-// actual toggle lives.
-function ApiEnvBadge() {
+// actual toggle lives — this is just an indicator + shortcut, not the
+// toggle itself, so no reload is needed.
+function ApiEnvBadge({ onJumpToAdmin }: { onJumpToAdmin: () => void }) {
   const env = getApiEnv();
-  const isStaging = env === "staging";
+  const color =
+    env === "prod" ? "var(--accent-primary)" :
+    env === "staging" ? "#f0a030" :
+    "#ff4060"; // custom — red so it can't be confused with the two canonical envs
+  const bg =
+    env === "prod" ? "var(--accent-primary-dim)" :
+    env === "staging" ? "#f0a03015" :
+    "#ff406015";
+  const border =
+    env === "prod" ? "#00e5c830" :
+    env === "staging" ? "#f0a03040" :
+    "#ff406040";
   return (
-    <div
-      onClick={() => { window.location.hash = "#admin"; window.location.reload(); }}
+    <button
+      type="button"
+      onClick={onJumpToAdmin}
       title="Click to open Admin panel and switch environments"
+      aria-label={`API environment: ${env} — click to open Admin panel`}
       style={{
         marginLeft: "0.75rem",
         padding: "0.15rem 0.5rem",
@@ -38,13 +52,13 @@ function ApiEnvBadge() {
         letterSpacing: "0.08em",
         cursor: "pointer",
         userSelect: "none" as const,
-        color: isStaging ? "#f0a030" : "var(--accent-primary)",
-        background: isStaging ? "#f0a03015" : "var(--accent-primary-dim)",
-        border: `1px solid ${isStaging ? "#f0a03040" : "#00e5c830"}`,
+        color,
+        background: bg,
+        border: `1px solid ${border}`,
       }}
     >
       {env}
-    </div>
+    </button>
   );
 }
 
@@ -153,7 +167,7 @@ export default function Dashboard() {
             <div className="header-title">Lantern</div>
             <div className="header-subtitle">Bandit Dashboard</div>
           </div>
-          <ApiEnvBadge />
+          <ApiEnvBadge onJumpToAdmin={() => switchTab("admin")} />
         </div>
         <div style={{ display: "flex", gap: "0.25rem", marginLeft: "1.5rem" }}>
           {(["map", "overview", "vps", "arms", "tracks", "bandwidth", "proxy", "admin"] as const).map((tab) => (


### PR DESCRIPTION
## Summary

Lets an operator switch which lantern-cloud API the dashboard talks to, per-browser:
- **prod**: \`api.iantem.io\`
- **staging**: \`api.staging.iantem.io\`

Needed because merging \`main\` in lantern-cloud deploys prod and merging \`staging\` deploys staging — two distinct APIs that previously required rebuilding the dashboard or pointing \`VITE_API_URL\` at a different value. This lets me flip between them to verify a staging rollout before touching prod.

## What changed

- \`api/client.ts\` — centralized URL resolution via \`getApiUrl()\` / \`getApiEnv()\` / \`setApiEnv()\`. Reads from \`localStorage\` first, then \`VITE_API_URL\` (build-time, still used for local dev tunnels), then defaults to prod. Every fetch in the file now uses \`getApiUrl()\` so a post-toggle reload hits the new endpoint.
- \`AdminPanel.tsx\` — new "API Environment" card above Bandit Reset. Shows current env + buttons for prod / staging; active is disabled, inactive persists and reloads.
- \`Dashboard.tsx\` — always-visible \`ApiEnvBadge\` in the header next to the subtitle. Teal for prod, amber for staging. Clicking jumps to \`#admin\`.
- \`AISummary.tsx\` — drops its local \`API_URL\` const in favor of \`getApiUrl()\` so the AI-summary streaming endpoint also follows the toggle.

## Test plan

- [ ] Open the dashboard, badge shows "prod" (teal) by default
- [ ] Admin tab → click "staging" → page reloads, badge turns amber and shows "staging"
- [ ] Network tab confirms requests go to \`api.staging.iantem.io\`
- [ ] Click "prod" → reload, back to teal
- [ ] Confirm \`VITE_API_URL\` override still works for local dev (unset localStorage key, set build-time env to a tunnel URL, requests go there)