### PR TITLE
map: permalinks for country and ASN selection

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -105,12 +105,21 @@ export default function Dashboard() {
   );
   const { self: myGeo, peers: peerGeos } = useGeoLookup(connectionAddrs, proxy.isRunning);
   const [mapSelection, setMapSelection] = useState<MapSelection>({ country: null, asn: null, asnName: null, countryASNs: [] });
-  // Read initial map selection from ?country=XX&asn=ASYYYY so the URL is
+  // Read initial map selection from ?country=XX&asn=YYYY so the URL is
   // shareable. Captured once at mount; subsequent changes are pushed back
-  // into the URL via handleSelectionChange below.
+  // into the URL via handleSelectionChange below. Normalize & validate here
+  // so a permalink like ?country=cn&asn=as4134 — or the naked variant
+  // ?country=cn&asn=4134 — restores correctly. Map data is keyed by
+  // uppercase ISO country codes and ASNs with the "AS" prefix.
   const [initialMapCountry, initialMapAsn] = useMemo(() => {
     const params = new URLSearchParams(window.location.search);
-    return [params.get("country"), params.get("asn")] as const;
+    const country = params.get("country")?.trim().toUpperCase() ?? "";
+    const rawAsn = params.get("asn")?.trim().toUpperCase() ?? "";
+    const asnMatch = rawAsn.match(/^(?:AS)?(\d+)$/);
+    return [
+      /^[A-Z]{2}$/.test(country) ? country : null,
+      asnMatch ? `AS${asnMatch[1]}` : null,
+    ] as const;
   }, []);
   const handleSelectionChange = useCallback((sel: MapSelection) => {
     setMapSelection(sel);

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -105,8 +105,28 @@ export default function Dashboard() {
   );
   const { self: myGeo, peers: peerGeos } = useGeoLookup(connectionAddrs, proxy.isRunning);
   const [mapSelection, setMapSelection] = useState<MapSelection>({ country: null, asn: null, asnName: null, countryASNs: [] });
+  // Read initial map selection from ?country=XX&asn=ASYYYY so the URL is
+  // shareable. Captured once at mount; subsequent changes are pushed back
+  // into the URL via handleSelectionChange below.
+  const [initialMapCountry, initialMapAsn] = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    return [params.get("country"), params.get("asn")] as const;
+  }, []);
   const handleSelectionChange = useCallback((sel: MapSelection) => {
     setMapSelection(sel);
+    // Mirror the current selection into the URL so users can share a link.
+    // replaceState (not pushState) keeps the back button sane — selecting an
+    // ASN shouldn't add history entries.
+    const params = new URLSearchParams(window.location.search);
+    if (sel.country) params.set("country", sel.country);
+    else params.delete("country");
+    if (sel.asn) params.set("asn", sel.asn);
+    else params.delete("asn");
+    const query = params.toString();
+    const next = `${window.location.pathname}${query ? "?" + query : ""}${window.location.hash}`;
+    if (next !== `${window.location.pathname}${window.location.search}${window.location.hash}`) {
+      window.history.replaceState(null, "", next);
+    }
   }, []);
 
   // Compute filtered stats based on map selection
@@ -302,6 +322,8 @@ export default function Dashboard() {
             myProxyView={myProxyView}
             myGeo={myGeo}
             peerGeos={peerGeos}
+            initialCountry={initialMapCountry}
+            initialAsn={initialMapAsn}
           />
           <div className="map-legend">
             {proxy.isRunning && (

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -197,6 +197,11 @@ interface WorldMapProps {
   myProxyView?: boolean;
   myGeo?: GeoResult | null;
   peerGeos?: GeoResult[];
+  // Seed the internal selection on mount so permalinks like
+  // ?country=CN&asn=AS4134 can deep-link into a specific ASN.
+  // Consumed only at mount; later selection is driven by user clicks.
+  initialCountry?: string | null;
+  initialAsn?: string | null;
 }
 
 // Provider colors — each cloud provider gets a distinct hue
@@ -990,13 +995,17 @@ const PeerMarker = memo(function PeerMarker({ geo, index }: { geo: GeoResult; in
   );
 });
 
-function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange, myProxyView, myGeo, peerGeos }: WorldMapProps) {
+function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange, myProxyView, myGeo, peerGeos, initialCountry, initialAsn }: WorldMapProps) {
   const [pulseIndex, setPulseIndex] = useState(0);
   const [projectionFn, setProjectionFn] = useState<((c: [number, number]) => [number, number] | null) | null>(null);
-  const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
+  const [selectedCountry, setSelectedCountry] = useState<string | null>(initialCountry ?? null);
   const [selectedASN, setSelectedASN] = useState<string | null>(null);
   const [countryASNs, setCountryASNs] = useState<DashboardASN[]>([]);
   const [asnLoading, setAsnLoading] = useState(false);
+  // pendingAsnRef holds the ASN from a permalink (?country=CN&asn=AS4134)
+  // until the async ASN fetch resolves. A ref avoids retriggering the fetch
+  // effect when we consume it. One-shot: consumed on the next fetch completion.
+  const pendingAsnRef = useRef<string | null>(initialAsn ?? null);
 
   // Compute proxy nodes from real DC data, falling back to hardcoded
   // Split each DC into one node per provider, offset slightly so they don't stack
@@ -1069,19 +1078,30 @@ function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange,
     if (!selectedCountry) {
       setCountryASNs([]);
       setSelectedASN(null);
+      pendingAsnRef.current = null;
       return;
     }
-    setSelectedASN(null);
+    // setSelectedASN(null) is NOT called here — pendingAsnRef handles the
+    // permalink-restore case (initial mount), and handleGeoClick already
+    // clears selectedASN when the user switches to a different country.
     setAsnLoading(true);
 
     fetchASNs(selectedCountry)
       .then((asns) => {
-        setCountryASNs(asns.length > 0 ? asns : (MOCK_ISPS[selectedCountry] ?? []));
+        const resolved = asns.length > 0 ? asns : (MOCK_ISPS[selectedCountry] ?? []);
+        setCountryASNs(resolved);
         setAsnLoading(false);
+        // Apply permalink ASN only if it actually exists in the fetched list.
+        const pending = pendingAsnRef.current;
+        pendingAsnRef.current = null;
+        if (pending && resolved.some((a) => a.asn === pending)) {
+          setSelectedASN(pending);
+        }
       })
       .catch(() => {
         setCountryASNs(MOCK_ISPS[selectedCountry] ?? []);
         setAsnLoading(false);
+        pendingAsnRef.current = null;
       });
   }, [selectedCountry]);
 
@@ -1114,7 +1134,13 @@ function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange,
   }, [hasLiveData, liveCountries]);
 
   const handleGeoClick = useCallback((iso: string) => {
-    setSelectedCountry((prev) => (prev === iso ? null : iso));
+    setSelectedCountry((prev) => {
+      if (prev === iso) return null;
+      // Switching to a different country: drop any prior ASN selection so
+      // we don't carry CN's AS4134 over while the new country's list loads.
+      setSelectedASN(null);
+      return iso;
+    });
   }, []);
 
   const handleClearSelection = useCallback(() => {

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -1006,6 +1006,14 @@ function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange,
   // until the async ASN fetch resolves. A ref avoids retriggering the fetch
   // effect when we consume it. One-shot: consumed on the next fetch completion.
   const pendingAsnRef = useRef<string | null>(initialAsn ?? null);
+  // initialAsnPending gates onSelectionChange so the parent doesn't clobber
+  // the ?asn= URL param during the async restore window. Flipped to false
+  // once the fetch effect has either applied the pending ASN or determined
+  // there's nothing to apply. Only true if we actually have a permalink ASN
+  // paired with a country to look it up against.
+  const [initialAsnPending, setInitialAsnPending] = useState(
+    initialCountry != null && initialAsn != null,
+  );
 
   // Compute proxy nodes from real DC data, falling back to hardcoded
   // Split each DC into one node per provider, offset slightly so they don't stack
@@ -1043,15 +1051,18 @@ function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange,
     return PROXY_NODES.map((n) => ({ ...n, dc: null, color: "#00e5c8" }));
   }, [dataCenters]);
 
-  // Notify parent of selection changes
+  // Notify parent of selection changes. Suppressed during the initial
+  // permalink-restore window so Dashboard's URL mirror doesn't strip the
+  // ?asn= param before we've had a chance to apply it from pendingAsnRef.
   useEffect(() => {
+    if (initialAsnPending) return;
     onSelectionChange?.({
       country: selectedCountry,
       asn: selectedASN,
       asnName: selectedASN ? asnDisplayName(selectedASN) : null,
       countryASNs,
     });
-  }, [selectedCountry, selectedASN, countryASNs, onSelectionChange]);
+  }, [selectedCountry, selectedASN, countryASNs, onSelectionChange, initialAsnPending]);
   const hasLiveData = liveCountries && liveCountries.length > 0;
 
   // Pre-compute set for O(1) lookups in geography render loop
@@ -1079,15 +1090,21 @@ function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange,
       setCountryASNs([]);
       setSelectedASN(null);
       pendingAsnRef.current = null;
+      setInitialAsnPending(false);
       return;
     }
     // setSelectedASN(null) is NOT called here — pendingAsnRef handles the
     // permalink-restore case (initial mount), and handleGeoClick already
     // clears selectedASN when the user switches to a different country.
     setAsnLoading(true);
+    // cancelled guards against a second click (country A → B) landing A's
+    // resolved promise after B's fetch has already started. Without this,
+    // A's ASNs would overwrite B's in countryASNs.
+    let cancelled = false;
 
     fetchASNs(selectedCountry)
       .then((asns) => {
+        if (cancelled) return;
         const resolved = asns.length > 0 ? asns : (MOCK_ISPS[selectedCountry] ?? []);
         setCountryASNs(resolved);
         setAsnLoading(false);
@@ -1097,12 +1114,19 @@ function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange,
         if (pending && resolved.some((a) => a.asn === pending)) {
           setSelectedASN(pending);
         }
+        setInitialAsnPending(false);
       })
       .catch(() => {
+        if (cancelled) return;
         setCountryASNs(MOCK_ISPS[selectedCountry] ?? []);
         setAsnLoading(false);
         pendingAsnRef.current = null;
+        setInitialAsnPending(false);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [selectedCountry]);
 
   // Build "My Proxy" arcs from self → each peer
@@ -1134,14 +1158,15 @@ function WorldMap({ liveCountries, dataCenters, trafficFlows, onSelectionChange,
   }, [hasLiveData, liveCountries]);
 
   const handleGeoClick = useCallback((iso: string) => {
-    setSelectedCountry((prev) => {
-      if (prev === iso) return null;
-      // Switching to a different country: drop any prior ASN selection so
-      // we don't carry CN's AS4134 over while the new country's list loads.
-      setSelectedASN(null);
-      return iso;
-    });
-  }, []);
+    if (selectedCountry === iso) {
+      setSelectedCountry(null);
+      return;
+    }
+    // Switching to a different country: drop any prior ASN selection so
+    // we don't carry CN's AS4134 over while the new country's list loads.
+    setSelectedCountry(iso);
+    setSelectedASN(null);
+  }, [selectedCountry]);
 
   const handleClearSelection = useCallback(() => {
     setSelectedCountry(null);


### PR DESCRIPTION
Adds `?country=XX&asn=ASYYYY` query params so a specific ASN view on the map is shareable.

## Flow

1. On mount, Dashboard parses `window.location.search` and pulls `country` / `asn` out
2. They're passed as `initialCountry` / `initialAsn` props to `WorldMap`
3. WorldMap seeds `selectedCountry` state directly; the ASN is parked in `pendingAsnRef` because `fetchASNs(country)` is async
4. When the ASN list resolves, the ref is consumed and applied only if the ASN actually exists in the list (typoed/stale params silently fall through to country-level view, no hanging "loading")
5. Every subsequent selection change flows back out via `onSelectionChange` → Dashboard writes `history.replaceState` so the URL always matches the current view

## Example URLs

- `/?country=CN` — China country view
- `/?country=CN&asn=AS4134` — China Telecom (AS4134) view
- `/?country=RU&asn=AS12389#bandwidth` — tab-agnostic (`#bandwidth` is preserved; the permalink applies to the map view whether or not it's currently visible)

## Small behavior adjustment

`handleGeoClick` now clears `selectedASN` when switching to a different country. Before, the fetch effect's early `setSelectedASN(null)` handled this implicitly. I removed that line so permalink restore isn't clobbered mid-fetch, so the explicit clear moved up into the click handler.

## Test plan

- [x] `tsc -b` — no type errors
- [x] `vite build` — no build errors
- [x] `eslint` — no new warnings (3 pre-existing, same count as main)
- [x] Dev server starts clean
- [ ] Manual smoke test: load `/?country=CN&asn=AS4134`, click clear, verify URL strips both params

🤖 Generated with [Claude Code](https://claude.com/claude-code)