### PR TITLE
arms: apply permalink country+asn on mount

### DIFF
--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -947,9 +947,7 @@ function BanditArmsOverview({ countries, dataCenters, isLive, initialCountry, in
     return map;
   }, [dataCenters]);
   const asnDB = useASNNames();
-  const [expandedCountries, setExpandedCountries] = useState<Set<string>>(
-    () => (initialCountry ? new Set([initialCountry]) : new Set()),
-  );
+  const [expandedCountries, setExpandedCountries] = useState<Set<string>>(new Set());
   const [expandedASNs, setExpandedASNs] = useState<Set<string>>(new Set());
   const [asnCache, setAsnCache] = useState<Map<string, DashboardASN[]>>(new Map());
   const [loadingCountries, setLoadingCountries] = useState<Set<string>>(new Set());
@@ -1100,29 +1098,60 @@ function BanditArmsOverview({ countries, dataCenters, isLive, initialCountry, in
     });
   }, []);
 
-  // Permalink expansion: the background refresh effect below populates
-  // asnCache for every country. Once the initial country's entry lands
-  // we match the permalink ASN (stripping/adding "AS" since the API keys
-  // may be in either form), expand that ISPSection, and scroll it into
-  // view. Guarded by a ref so it only fires once per mount — if the user
-  // collapses the section afterwards we don't re-expand on re-render.
+  // Permalink expansion runs in two phases:
+  //
+  //   Phase 1 (mount): call toggleCountry(initialCountry) so the country
+  //   both expands AND gets loadingCountries + an immediate fetch — without
+  //   this the pre-expanded body renders blank until the 30s refreshAll
+  //   effect happens to populate asnCache, which is the exact "blank arms
+  //   page" symptom the permalink is supposed to fix.
+  //
+  //   Phase 2 (asnCache update): once the initial country's ASN list lands
+  //   we match the permalink ASN (stripping/adding "AS" since API keys may
+  //   be in either form), expand the ISPSection, and scroll it into view.
+  //   The ref flips to true only when we've actually succeeded (country-
+  //   only permalink → flip after first fetch; ASN permalink → flip after
+  //   scrollIntoView finds the DOM node). A match miss leaves the ref
+  //   unset so a later refresh can retry, but in practice fetchASNs
+  //   returns the full list so a miss is definitive.
   const permalinkAppliedRef = useRef(false);
+  const mountTriggeredRef = useRef(false);
+  useEffect(() => {
+    if (mountTriggeredRef.current) return;
+    if (!initialCountry) return;
+    mountTriggeredRef.current = true;
+    void toggleCountry(initialCountry);
+  }, [initialCountry, toggleCountry]);
+
   useEffect(() => {
     if (permalinkAppliedRef.current) return;
     if (!initialCountry) return;
     const asns = asnCache.get(initialCountry);
     if (!asns) return;
-    permalinkAppliedRef.current = true;
-    if (!initialAsn) return;
+    if (!initialAsn) {
+      // Country-only permalink — the toggleCountry above already expanded it.
+      permalinkAppliedRef.current = true;
+      return;
+    }
     const naked = initialAsn.replace(/^AS/i, "");
     const match = asns.find((a) => a.asn === initialAsn || a.asn === naked || a.asn === `AS${naked}`);
     if (!match) return;
     const key = `${initialCountry}-${match.asn}`;
-    setExpandedASNs((prev) => new Set(prev).add(key));
-    requestAnimationFrame(() => {
+    setExpandedASNs((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
+    // CountryRow → ISPSection hasn't mounted on this frame yet. Retry on
+    // successive animation frames; flip the ref only after scroll succeeds
+    // so we don't declare victory too early and lock out later updates.
+    let frames = 0;
+    const tryScroll = () => {
       const el = document.getElementById(`isp-${key}`);
-      if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
-    });
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        permalinkAppliedRef.current = true;
+        return;
+      }
+      if (++frames < 10) requestAnimationFrame(tryScroll);
+    };
+    requestAnimationFrame(tryScroll);
   }, [asnCache, initialCountry, initialAsn]);
 
   if (countries.length === 0) {

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, memo, type CSSProperties } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef, memo, type CSSProperties } from "react";
 import type {
   DashboardCountry,
   DashboardASN,
@@ -11,6 +11,13 @@ interface BanditArmsOverviewProps {
   countries: DashboardCountry[];
   dataCenters?: DashboardDataCenter[];
   isLive?: boolean;
+  // Permalink hooks: on mount, auto-expand this country (fetching its ASN
+  // list) and — once the list loads — auto-expand the named ASN and scroll
+  // it into view. Lets a URL like /?country=RU&asn=12389#arms deep-link
+  // straight to Rostelecom's arms view. Consumed once on mount; subsequent
+  // interactions are user-driven.
+  initialCountry?: string | null;
+  initialAsn?: string | null;
 }
 
 // Lazy-loaded ASN → org name database (121K entries, ~1.5MB gzipped)
@@ -560,7 +567,7 @@ function ISPSection({ asn, country, expandedASNs, toggleASN, asnDB, regionToCity
   const showFullLoadButton = expanded && allArms === null && hasMoreBeyondSnapshot;
 
   return (
-    <div>
+    <div id={`isp-${key}`}>
       <div
         style={{ ...ispRowStyle, background: severityBg[severity], borderLeft: severityBorder[severity] }}
         onClick={() => toggleASN(key)}
@@ -929,7 +936,7 @@ function CountryRow({
   );
 }
 
-function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOverviewProps) {
+function BanditArmsOverview({ countries, dataCenters, isLive, initialCountry, initialAsn }: BanditArmsOverviewProps) {
   const regionToCity = useMemo(() => {
     const map = new Map<string, string>();
     if (dataCenters) {
@@ -940,7 +947,9 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
     return map;
   }, [dataCenters]);
   const asnDB = useASNNames();
-  const [expandedCountries, setExpandedCountries] = useState<Set<string>>(new Set());
+  const [expandedCountries, setExpandedCountries] = useState<Set<string>>(
+    () => (initialCountry ? new Set([initialCountry]) : new Set()),
+  );
   const [expandedASNs, setExpandedASNs] = useState<Set<string>>(new Set());
   const [asnCache, setAsnCache] = useState<Map<string, DashboardASN[]>>(new Map());
   const [loadingCountries, setLoadingCountries] = useState<Set<string>>(new Set());
@@ -1090,6 +1099,31 @@ function BanditArmsOverview({ countries, dataCenters, isLive }: BanditArmsOvervi
       return next;
     });
   }, []);
+
+  // Permalink expansion: the background refresh effect below populates
+  // asnCache for every country. Once the initial country's entry lands
+  // we match the permalink ASN (stripping/adding "AS" since the API keys
+  // may be in either form), expand that ISPSection, and scroll it into
+  // view. Guarded by a ref so it only fires once per mount — if the user
+  // collapses the section afterwards we don't re-expand on re-render.
+  const permalinkAppliedRef = useRef(false);
+  useEffect(() => {
+    if (permalinkAppliedRef.current) return;
+    if (!initialCountry) return;
+    const asns = asnCache.get(initialCountry);
+    if (!asns) return;
+    permalinkAppliedRef.current = true;
+    if (!initialAsn) return;
+    const naked = initialAsn.replace(/^AS/i, "");
+    const match = asns.find((a) => a.asn === initialAsn || a.asn === naked || a.asn === `AS${naked}`);
+    if (!match) return;
+    const key = `${initialCountry}-${match.asn}`;
+    setExpandedASNs((prev) => new Set(prev).add(key));
+    requestAnimationFrame(() => {
+      const el = document.getElementById(`isp-${key}`);
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  }, [asnCache, initialCountry, initialAsn]);
 
   if (countries.length === 0) {
     return (

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -302,7 +302,13 @@ export default function Dashboard() {
             error={vpsData.error}
           />
         ) : activeTab === "arms" ? (
-          <BanditArmsOverview countries={globalStats.countries} dataCenters={dataCenters} isLive={isLive} />
+          <BanditArmsOverview
+            countries={globalStats.countries}
+            dataCenters={dataCenters}
+            isLive={isLive}
+            initialCountry={initialMapCountry}
+            initialAsn={initialMapAsn}
+          />
         ) : activeTab === "tracks" ? (
           <TracksOverview />
         ) : activeTab === "bandwidth" ? (


### PR DESCRIPTION
Follow-up to #54. Slack users are trying to click `/?country=RU&asn=12389#arms` links and land on the *Bandit Arms* view for Rostelecom, but the #arms tab wasn't wired up to the permalink plumbing yet — clicks opened a blank Arms page, Russia collapsed.

## What this does

A URL like `/?country=RU&asn=12389#arms` now:

1. Opens the Arms tab (via the existing hash handler)
2. Pre-expands Russia so its ISPSections render
3. Once the background ASN-refresh effect populates `asnCache` for RU, matches AS12389 against the list (accepts either `12389` or `AS12389`), expands that ISPSection, and scrolls it into the viewport

Guarded by a one-shot ref so the user can collapse the section after landing without re-render re-expanding it.

## Wiring

- `BanditArmsOverview` gets two new optional props: `initialCountry`, `initialAsn`
- `Dashboard` forwards `initialMapCountry` / `initialMapAsn` (the same values it already computes for WorldMap) so a single URL drives both tabs
- `ISPSection` gets an `id="isp-${key}"` on its outer div so `scrollIntoView` has a target

## Test plan

- [x] `tsc -b` — no new type errors
- [x] `vite build` — clean
- [x] `eslint` — no new warnings
- [ ] Manual: open `https://bandit.lantern.io/?country=RU&asn=12389#arms`, verify Russia expanded, Rostelecom expanded, section scrolled into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)