### PR TITLE
fix(tracks): apply transmit filter on proxy.io throughput query

### DIFF
--- a/src/components/TracksOverview.tsx
+++ b/src/components/TracksOverview.tsx
@@ -343,7 +343,12 @@ function TracksOverview() {
     const startMs = endMs - (rangeMs[metricsTimeRange] || 21600000);
 
     // SigNoz v5 builder format — matches the existing "Track Performance Overview" dashboard panels.
-    const buildQuery = (metricName: string, timeAgg: string, spaceAgg: string, _filterExpr: string, groupByKey: string) => ({
+    type FilterItem = {
+      key: { key: string; dataType: string; type: string; isColumn: boolean; isJSON: boolean };
+      op: string;
+      value: string;
+    };
+    const buildQuery = (metricName: string, timeAgg: string, spaceAgg: string, filterItems: FilterItem[], groupByKey: string) => ({
       start: startMs,
       end: endMs,
       compositeQuery: {
@@ -356,7 +361,7 @@ function TracksOverview() {
             aggregateAttribute: { key: metricName, dataType: "float64", type: "Sum", isColumn: true, isJSON: false },
             timeAggregation: timeAgg,
             spaceAggregation: spaceAgg,
-            filters: { items: [], op: "AND" },
+            filters: { items: filterItems, op: "AND" },
             expression: "A",
             disabled: false,
             groupBy: [{ key: groupByKey, dataType: "string", type: "tag", isColumn: false, isJSON: false }],
@@ -371,11 +376,20 @@ function TracksOverview() {
       },
     });
 
+    // proxy.io carries direction tags (transmit | receive). Filtering to transmit
+    // matches the egress-bandwidth semantics shown elsewhere on the dashboard;
+    // without it, throughputBps would silently double-count both directions.
+    const transmitOnly: FilterItem[] = [{
+      key: { key: "network.io.direction", dataType: "string", type: "tag", isColumn: false, isJSON: false },
+      op: "=",
+      value: "transmit",
+    }];
+
     const queries = [
-      { key: "throughputBps" as const, query: buildQuery("proxy.io", "rate", "sum", "network.io.direction = 'transmit'", "proxy.track") },
-      { key: "connections" as const, query: buildQuery("proxy.connections", "increase", "sum", "", "proxy.track") },
-      { key: "callbacks" as const, query: buildQuery("bandit.callbacks", "increase", "sum", "", "proxy.track") },
-      { key: "selections" as const, query: buildQuery("bandit.selections", "increase", "sum", "", "proxy.track") },
+      { key: "throughputBps" as const, query: buildQuery("proxy.io", "rate", "sum", transmitOnly, "proxy.track") },
+      { key: "connections" as const, query: buildQuery("proxy.connections", "increase", "sum", [], "proxy.track") },
+      { key: "callbacks" as const, query: buildQuery("bandit.callbacks", "increase", "sum", [], "proxy.track") },
+      { key: "selections" as const, query: buildQuery("bandit.selections", "increase", "sum", [], "proxy.track") },
     ];
 
     const result: TrackMetrics = { throughputBps: {}, connections: {}, callbacks: {}, selections: {} };

--- a/src/components/TracksOverview.tsx
+++ b/src/components/TracksOverview.tsx
@@ -346,7 +346,7 @@ function TracksOverview() {
     type FilterItem = {
       key: { key: string; dataType: string; type: string; isColumn: boolean; isJSON: boolean };
       op: string;
-      value: string;
+      value: string | number | boolean;
     };
     const buildQuery = (metricName: string, timeAgg: string, spaceAgg: string, filterItems: FilterItem[], groupByKey: string) => ({
       start: startMs,


### PR DESCRIPTION
## Summary

`TracksOverview.tsx` builds SigNoz queries with `_filterExpr: string` as the 4th `buildQuery` arg, but the parameter is unused — the underscore prefix was added in 219b1844 to silence a TS unused-var warning without wiring the filter through. Result: `filters: { items: [], op: "AND" }` was always empty, so `proxy.io` was being summed across both `transmit` and `receive`, roughly doubling displayed throughput.

This re-types the param as a structured `FilterItem[]` (matching the `client.ts:filterItems` shape) and passes a `transmitOnly` filter only on the `throughputBps` query — the other three (`proxy.connections`, `bandit.callbacks`, `bandit.selections`) don't carry a direction tag and continue to pass `[]`.

## Why now

While investigating a discrepancy between dashboard bandwidth/duration and bandit health signals, I noticed the Tracks tab queries silently drop the direction filter. The newer `MetricsOverview` (`#metrics`) tab already does this correctly via `buildBandwidthQuery` in `client.ts`; this brings the older Tracks tab in line.

## Notes

- All tracks were affected the same way, so the bug was internally consistent — no per-track ordering change, just absolute numbers ~2× too high. Expect throughput readouts to drop after this lands; that's the fix, not a regression.
- Pre-existing `@typescript-eslint/no-explicit-any` warning on line 409 is untouched (not introduced by this change).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/components/TracksOverview.tsx` clean (modulo the pre-existing `any` warning)
- [ ] After deploy: confirm \"Tracks\" tab throughput values are roughly half what they were before, and ratios between tracks are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)