### PR TITLE
Bandit Experiments dashboard tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "globals": "^16.5.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.2"
+        "vite": "^7.3.2",
+        "vite-plugin-mkcert": "^1.17.12"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3873,6 +3874,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-mkcert": {
+      "version": "1.17.12",
+      "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.17.12.tgz",
+      "integrity": "sha512-HhLyUZnvkKLuk9o+HBaMlGIa6CqPTfLbVlLFBjrkN4mpZ4saYFRfFx5R12a46UxmzWT9dO8fijmblVvCYvCD3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=3"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "globals": "^16.5.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "vite-plugin-mkcert": "^1.17.12"
   }
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -609,3 +609,196 @@ export function getStreamURL(): string {
   if (authToken) url.searchParams.set("token", authToken);
   return url.toString();
 }
+
+// ── Bandit experiments ──
+// Types mirror cmd/api/dashboard_experiments_handler.go.
+
+export interface ExperimentSummary {
+  id: number;
+  status: string;
+  regionId: number;
+  regionName: string;
+  locationName: string;
+  providerName: string;
+  protocolName: string;
+  challengerTrackId?: number;
+  challengerTrackName?: string;
+  controlTrackId?: number;
+  controlTrackName?: string;
+  decision?: string;
+  decisionReason?: string;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  gatheringSince?: string;
+  decidedAt?: string;
+  gatheringHours?: number;
+  config?: unknown;
+}
+
+export interface ExperimentPipeline {
+  counts: Record<string, number>;
+  order: string[];
+}
+
+export interface ExperimentsResponse {
+  experiments: ExperimentSummary[];
+  pipeline: ExperimentPipeline;
+}
+
+export interface ExperimentStratum {
+  country: string;
+  challengerGoodput: number;
+  controlGoodput: number;
+  challengerSamples: number;
+  controlSamples: number;
+  challengerSuccessRate: number;
+  controlSuccessRate: number;
+  challengerAttempts: number;
+  controlAttempts: number;
+  qualifies: boolean;
+}
+
+export interface ExperimentDecisionPreview {
+  verdict: string;          // "promote" | "retire" | "hold"
+  reason: string;
+  qualifyingStrata: number;
+  wins: number;
+  losses: number;
+  minStrata: number;
+  winMargin: number;        // fraction, e.g. 0.40
+  minSamplesPerArm: number;
+}
+
+export interface ExperimentGuardrails {
+  blockingOk: boolean;
+  blockingReason?: string;
+  blockedRoutes: number;
+  totalRoutes: number;
+  maxBlockedFraction: number;
+  successOk: boolean;
+  successReason?: string;
+}
+
+export interface ExperimentDetail extends ExperimentSummary {
+  windowStart: string;
+  windowEnd: string;
+  strata: ExperimentStratum[] | null;
+  decisionPreview: ExperimentDecisionPreview;
+  guardrails: ExperimentGuardrails;
+  statsError?: string;
+}
+
+export interface ExperimentSetting {
+  key: string;
+  type: "bool" | "int" | "string";
+  label: string;
+  description: string;
+  default: boolean | number | string;
+  value: boolean | number | string;
+}
+
+export interface ExperimentConstant {
+  label: string;
+  value: string;
+  description: string;
+}
+
+export interface ExperimentSettingsResponse {
+  editable: ExperimentSetting[];
+  readOnly: ExperimentConstant[];
+  applyDelaySeconds: number;
+}
+
+export function fetchExperiments(): Promise<ExperimentsResponse> {
+  return apiFetch("/experiments");
+}
+
+export function fetchExperimentDetail(id: number): Promise<ExperimentDetail> {
+  return apiFetch("/experiments/detail", { id: String(id) });
+}
+
+export function fetchExperimentSettings(): Promise<ExperimentSettingsResponse> {
+  return apiFetch("/experiments/settings");
+}
+
+// updateExperimentSetting POSTs a single knob change. Mirrors resetBanditData's
+// non-GET style (apiFetch is GET-only) and reuses the 401 retry handler manually.
+export async function updateExperimentSetting(
+  key: string,
+  value: boolean | number | string,
+): Promise<ExperimentSetting> {
+  const url = `${getApiUrl()}/v1/dashboard/experiments/settings`;
+  const send = (token: string | null) => {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return fetch(url, { method: "POST", headers, body: JSON.stringify({ key, value }) });
+  };
+  let res = await send(authToken);
+  if (res.status === 401 && onAuthExpired) {
+    const newToken = await onAuthExpired();
+    if (newToken) {
+      authToken = newToken;
+      res = await send(newToken);
+    }
+  }
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Update setting failed: ${res.status} ${body}`);
+  }
+  return res.json();
+}
+
+// buildExperimentTrackQuery builds a SigNoz v5 builder query for a metric grouped
+// by track, filtered to a set of track names — used to chart a single experiment's
+// challenger vs control over time. trackKey differs by metric: the bandit probe
+// counters (bandit.callbacks/bandit.probes_expired) and the goodput histogram tag
+// `track`, while proxy.io tags `proxy.track`.
+export function buildExperimentTrackQuery(opts: {
+  metricName: string;
+  trackNames: string[];
+  trackKey?: string;            // defaults to "track"
+  timeAggregation: string;      // e.g. "rate" | "increase"
+  spaceAggregation: string;     // e.g. "sum" | "p50"
+  startMs: number;
+  endMs: number;
+  stepSeconds: number;
+  extraFilters?: { key: string; dataType: string; op: string; value: unknown }[];
+}): object {
+  const trackKey = opts.trackKey || "track";
+  const items: object[] = [
+    { key: { key: trackKey, dataType: "string", type: "tag", isColumn: false, isJSON: false }, op: "in", value: opts.trackNames },
+    ...(opts.extraFilters || []).map((f) => ({
+      key: { key: f.key, dataType: f.dataType, type: "tag", isColumn: false, isJSON: false },
+      op: f.op,
+      value: f.value,
+    })),
+  ];
+  return {
+    start: opts.startMs,
+    end: opts.endMs,
+    compositeQuery: {
+      queryType: "builder",
+      panelType: "graph",
+      builderQueries: {
+        A: {
+          dataSource: "metrics",
+          queryName: "A",
+          aggregateAttribute: { key: opts.metricName, dataType: "float64", type: "Sum", isColumn: true, isJSON: false },
+          timeAggregation: opts.timeAggregation,
+          spaceAggregation: opts.spaceAggregation,
+          filters: { items, op: "AND" },
+          expression: "A",
+          disabled: false,
+          groupBy: [{ key: trackKey, dataType: "string", type: "tag", isColumn: false, isJSON: false }],
+          legend: `{{${trackKey}}}`,
+          having: [],
+          limit: null,
+          orderBy: [],
+          reduceTo: "avg",
+          stepInterval: opts.stepSeconds,
+        },
+      },
+    },
+  };
+}

--- a/src/components/BanditArmsOverview.tsx
+++ b/src/components/BanditArmsOverview.tsx
@@ -799,6 +799,94 @@ function BanditHowItWorksContent() {
 
             <p style={{ marginTop: "0.35rem", color: "#667080" }}>Together: the pool worker ensures enough capacity exists (supply side), while EXP3.S distributes traffic optimally across available capacity (demand side). Neither mechanism alone is sufficient — the pool worker can't react faster than its 30-minute cycle, and EXP3.S can't create new infrastructure.</p>
           </div>
+
+          {/* Automatic Experiments Section */}
+          <div style={{ marginTop: "0.75rem", paddingTop: "0.6rem", borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+            <p style={{ fontWeight: 600, color: "#c0c8d4", fontSize: "0.75rem", marginBottom: "0.35rem" }}>Automatic experiments: testing new proxy configurations</p>
+
+            <p>The bandit can only choose among arms that already exist. <strong>Experiments</strong> are how new arms get created and proven: an automated A/B loop that proposes a fresh proxy configuration, runs it against the incumbent in a censored market, and promotes it only if it's measurably better — or retires it if it isn't.</p>
+
+            <svg viewBox="0 0 720 320" style={{ width: "100%", maxWidth: "720px", margin: "0.6rem 0" }}>
+              <defs>
+                <marker id="arrow-exp" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#00e5c8" /></marker>
+                <marker id="arrow-exp-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#50c878" /></marker>
+                <marker id="arrow-exp-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#ff5050" /></marker>
+                <marker id="arrow-exp-dim" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#a07820" /></marker>
+              </defs>
+
+              {/* Lifecycle row: Proposer → Realizer → Gathering → Evaluator */}
+              <rect x="8" y="24" width="150" height="54" rx="8" fill="rgba(100,180,255,0.1)" stroke="#64b4ff" strokeWidth="1.5" />
+              <text x="83" y="45" textAnchor="middle" fill="#64b4ff" fontSize="11" fontWeight="600">Proposer</text>
+              <text x="83" y="60" textAnchor="middle" fill="#8090a0" fontSize="8.5">untried region × DC ×</text>
+              <text x="83" y="71" textAnchor="middle" fill="#8090a0" fontSize="8.5">protocol (censored only)</text>
+
+              <rect x="190" y="24" width="150" height="54" rx="8" fill="rgba(100,180,255,0.1)" stroke="#64b4ff" strokeWidth="1.5" />
+              <text x="265" y="45" textAnchor="middle" fill="#64b4ff" fontSize="11" fontWeight="600">Realizer</text>
+              <text x="265" y="60" textAnchor="middle" fill="#8090a0" fontSize="8.5">spins up challenger track</text>
+              <text x="265" y="71" textAnchor="middle" fill="#8090a0" fontSize="8.5">1 VPS, ≤2% of free users</text>
+
+              <rect x="372" y="24" width="150" height="54" rx="8" fill="rgba(0,229,200,0.1)" stroke="#00e5c8" strokeWidth="1.5" />
+              <text x="447" y="45" textAnchor="middle" fill="#00e5c8" fontSize="11" fontWeight="600">Gathering ≥ 24h</text>
+              <text x="447" y="60" textAnchor="middle" fill="#8090a0" fontSize="8.5">challenger vs control</text>
+              <text x="447" y="71" textAnchor="middle" fill="#8090a0" fontSize="8.5">traffic, per country</text>
+
+              <rect x="554" y="24" width="158" height="54" rx="8" fill="rgba(255,180,50,0.1)" stroke="#ffb432" strokeWidth="1.5" />
+              <text x="633" y="45" textAnchor="middle" fill="#ffb432" fontSize="11" fontWeight="600">Evaluator</text>
+              <text x="633" y="60" textAnchor="middle" fill="#8090a0" fontSize="8.5">compares median goodput</text>
+              <text x="633" y="71" textAnchor="middle" fill="#8090a0" fontSize="8.5">per-country strata</text>
+
+              <line x1="158" y1="51" x2="186" y2="51" stroke="#64b4ff" strokeWidth="1.5" markerEnd="url(#arrow-exp)" />
+              <line x1="340" y1="51" x2="368" y2="51" stroke="#64b4ff" strokeWidth="1.5" markerEnd="url(#arrow-exp)" />
+              <line x1="522" y1="51" x2="550" y2="51" stroke="#00e5c8" strokeWidth="1.5" markerEnd="url(#arrow-exp)" />
+
+              {/* Decision rule */}
+              <rect x="372" y="148" width="170" height="62" rx="8" fill="rgba(255,180,50,0.06)" stroke="#ffb432" strokeWidth="1" strokeDasharray="4,3" />
+              <text x="457" y="168" textAnchor="middle" fill="#ffb432" fontSize="10.5" fontWeight="600">Big-win decision</text>
+              <text x="457" y="183" textAnchor="middle" fill="#8090a0" fontSize="8.5">challenger ≥ 40% faster</text>
+              <text x="457" y="195" textAnchor="middle" fill="#8090a0" fontSize="8.5">in a majority of ≥ 6</text>
+              <text x="457" y="206" textAnchor="middle" fill="#8090a0" fontSize="8.5">qualifying countries</text>
+              <line x1="620" y1="78" x2="500" y2="145" stroke="#ffb432" strokeWidth="1.5" markerEnd="url(#arrow-exp)" />
+
+              {/* Guardrails veto */}
+              <rect x="556" y="148" width="156" height="62" rx="8" fill="rgba(255,80,80,0.06)" stroke="#ff5050" strokeWidth="1" strokeDasharray="4,3" />
+              <text x="634" y="168" textAnchor="middle" fill="#ff5050" fontSize="10.5" fontWeight="600">Guardrails (veto)</text>
+              <text x="634" y="183" textAnchor="middle" fill="#8090a0" fontSize="8.5">blocking &lt; 50% of routes</text>
+              <text x="634" y="195" textAnchor="middle" fill="#8090a0" fontSize="8.5">success ≥ control − 10pp</text>
+              <text x="634" y="206" textAnchor="middle" fill="#8090a0" fontSize="8.5">else downgrade to hold</text>
+              <line x1="556" y1="179" x2="544" y2="179" stroke="#a07820" strokeWidth="1.2" strokeDasharray="3,2" markerEnd="url(#arrow-exp-dim)" />
+
+              {/* Outcomes */}
+              <rect x="250" y="248" width="184" height="56" rx="8" fill="rgba(80,200,120,0.1)" stroke="#50c878" strokeWidth="1.5" />
+              <text x="342" y="269" textAnchor="middle" fill="#50c878" fontSize="11" fontWeight="600">Promote → staged ramp</text>
+              <text x="342" y="284" textAnchor="middle" fill="#8090a0" fontSize="8.5">10% → 50% → 100% of free users,</text>
+              <text x="342" y="295" textAnchor="middle" fill="#8090a0" fontSize="8.5">re-checking blocking at each step</text>
+
+              <rect x="470" y="248" width="150" height="56" rx="8" fill="rgba(255,80,80,0.1)" stroke="#ff5050" strokeWidth="1.5" />
+              <text x="545" y="269" textAnchor="middle" fill="#ff5050" fontSize="11" fontWeight="600">Retire</text>
+              <text x="545" y="284" textAnchor="middle" fill="#8090a0" fontSize="8.5">tear down, free the</text>
+              <text x="545" y="295" textAnchor="middle" fill="#8090a0" fontSize="8.5">experiment budget</text>
+
+              <line x1="430" y1="210" x2="360" y2="245" stroke="#50c878" strokeWidth="1.5" markerEnd="url(#arrow-exp-green)" />
+              <text x="360" y="232" textAnchor="middle" fill="#50c878" fontSize="8.5">win</text>
+              <line x1="492" y1="210" x2="528" y2="245" stroke="#ff5050" strokeWidth="1.5" markerEnd="url(#arrow-exp-red)" />
+              <text x="540" y="232" textAnchor="middle" fill="#ff5050" fontSize="8.5">loss / 14d timeout</text>
+
+              {/* Promote feeds back into the catalog */}
+              <line x1="250" y1="276" x2="83" y2="276" stroke="#50c878" strokeWidth="1" strokeDasharray="4,3" />
+              <line x1="83" y1="276" x2="83" y2="82" stroke="#50c878" strokeWidth="1" strokeDasharray="4,3" markerEnd="url(#arrow-exp-green)" />
+              <text x="150" y="270" textAnchor="middle" fill="#50c878" fontSize="8">promoted track becomes a normal arm</text>
+            </svg>
+
+            <p style={{ marginTop: "0.35rem" }}>A <strong>challenger</strong> is one new proxy configuration — a single region × datacenter × protocol — provisioned as a tiny track. It's measured against the <strong>control</strong>: the established track free users in that region already get. Experiments only run in <strong>censored markets</strong> (default CN, RU, IR, MM), where a better config matters most.</p>
+
+            <p style={{ marginTop: "0.35rem" }}>Three background workers drive the loop. The <strong>proposer</strong> enumerates untried combinations and launches a budgeted batch (capped by max-concurrent and per-region limits). The <strong>realizer</strong> turns a proposal into a live challenger track — one VPS serving at most ~2% of free clients, so a bad config can't hurt many people. The <strong>evaluator</strong>, after at least <strong>24 hours</strong> of gathering, compares the median download <strong>goodput</strong> of challenger vs control within each client country.</p>
+
+            <p style={{ marginTop: "0.35rem" }}>The decision rule optimizes for <strong>big wins</strong>: a challenger is promoted only if it beats the control by <strong>≥ 40%</strong> in a majority of qualifying country strata (each needs ≥ 6 strata with ≥ 50 sessions per arm). A symmetric loss — or an inconclusive result after <strong>14 days</strong> — retires it; anything in between holds for more data.</p>
+
+            <p style={{ marginTop: "0.35rem" }}>Two <strong>guardrails</strong> can veto a goodput win: a challenger whose routes are getting <strong>blocked</strong> (≥ 50%) or whose connect/<strong>success rate</strong> trails the control by more than 10 percentage points is downgraded to hold — a fast-but-flaky or already-detected config never wins on speed alone. A promotion then <strong>ramps in stages</strong> (10% → 50% → 100% of free users), re-checking the blocking guardrail at each step and rolling back if it regresses. Once at 100%, the challenger becomes an ordinary track in the catalog and the bandit takes over.</p>
+
+            <p style={{ marginTop: "0.35rem", color: "#667080" }}>Every stage is gated by settings and starts disabled. With <em>auto-act</em> off the evaluator only logs the recommendation it would make (recommend-only); turning it on lets it actually promote and retire. Watch the live pipeline, per-experiment stats, and tune these knobs on the <strong>Experiments</strong> tab.</p>
+          </div>
         </div>
   );
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import ProtocolFeed from "./ProtocolFeed";
 import ProxyWidget from "./ProxyWidget";
 import VPSOverview from "./VPSOverview";
 import BanditArmsOverview, { BanditHowItWorks } from "./BanditArmsOverview";
+import ExperimentsOverview from "./ExperimentsOverview";
 import TracksOverview from "./TracksOverview";
 import MetricsOverview from "./MetricsOverview";
 import AISummary from "./AISummary";
@@ -81,11 +82,12 @@ function LanternLogo() {
 export default function Dashboard() {
   const { isAuthenticated, user, logout, token } = useAuth();
   const { globalStats, dataCenters, activityEvents, trafficFlows, isLive, blockedRoutes, demoMode, toggleDemoMode } = useLiveData();
-  const [activeTab, setActiveTab] = useState<'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'metrics' | 'proxy' | 'admin'>(() => {
+  const [activeTab, setActiveTab] = useState<'map' | 'overview' | 'vps' | 'arms' | 'experiments' | 'tracks' | 'metrics' | 'proxy' | 'admin'>(() => {
     const hash = window.location.hash;
     if (hash === '#overview') return 'overview';
     if (hash === '#vps') return 'vps';
     if (hash === '#arms') return 'arms';
+    if (hash === '#experiments') return 'experiments';
     if (hash === '#tracks') return 'tracks';
     // Accept #metrics (new) and #bandwidth (existing bookmarks) as the same tab.
     if (hash === '#metrics' || hash === '#bandwidth') return 'metrics';
@@ -93,7 +95,7 @@ export default function Dashboard() {
     if (hash === '#admin') return 'admin';
     return 'map';
   });
-  const switchTab = useCallback((tab: 'map' | 'overview' | 'vps' | 'arms' | 'tracks' | 'metrics' | 'proxy' | 'admin') => {
+  const switchTab = useCallback((tab: 'map' | 'overview' | 'vps' | 'arms' | 'experiments' | 'tracks' | 'metrics' | 'proxy' | 'admin') => {
     setActiveTab(tab);
     window.location.hash = tab === 'map' ? '' : `#${tab}`;
   }, []);
@@ -200,7 +202,7 @@ export default function Dashboard() {
           <ApiEnvBadge onJumpToAdmin={() => switchTab("admin")} />
         </div>
         <div style={{ display: "flex", gap: "0.25rem", marginLeft: "1.5rem" }}>
-          {(["map", "overview", "vps", "arms", "tracks", "metrics", "proxy", "admin"] as const).map((tab) => (
+          {(["map", "overview", "vps", "arms", "experiments", "tracks", "metrics", "proxy", "admin"] as const).map((tab) => (
             <div
               key={tab}
               onClick={() => switchTab(tab)}
@@ -218,7 +220,7 @@ export default function Dashboard() {
                 letterSpacing: "0.05em",
               }}
             >
-              {{ map: "Map", overview: "Overview", vps: "VPS Fleet", arms: "Bandit Arms", tracks: "Tracks", metrics: "Metrics", proxy: "Share Proxy", admin: "Admin" }[tab]}
+              {{ map: "Map", overview: "Overview", vps: "VPS Fleet", arms: "Bandit Arms", experiments: "Experiments", tracks: "Tracks", metrics: "Metrics", proxy: "Share Proxy", admin: "Admin" }[tab]}
             </div>
           ))}
         </div>
@@ -310,6 +312,8 @@ export default function Dashboard() {
             initialCountry={initialMapCountry}
             initialAsn={initialMapAsn}
           />
+        ) : activeTab === "experiments" ? (
+          <ExperimentsOverview enabled={activeTab === "experiments"} />
         ) : activeTab === "tracks" ? (
           <TracksOverview />
         ) : activeTab === "metrics" ? (

--- a/src/components/ExperimentSettings.tsx
+++ b/src/components/ExperimentSettings.tsx
@@ -52,12 +52,13 @@ const knobDesc: CSSProperties = {
   lineHeight: 1.35,
 };
 
-function Toggle({ on, disabled, onClick }: { on: boolean; disabled: boolean; onClick: () => void }) {
+function Toggle({ on, disabled, onClick, label }: { on: boolean; disabled: boolean; onClick: () => void; label?: string }) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={on}
+      aria-label={label}
       disabled={disabled}
       onClick={onClick}
       style={{
@@ -100,6 +101,13 @@ export default function ExperimentSettings({ settings, isLoading, error, onSaved
     setRowError((e) => ({ ...e, [key]: "" }));
     try {
       await updateExperimentSetting(key, value);
+      // Drop the local draft so the field falls back to the authoritative
+      // server value (normalized — e.g. an int shows 7, not the typed "007").
+      setDrafts((d) => {
+        const next = { ...d };
+        delete next[key];
+        return next;
+      });
       onSaved();
     } catch (err) {
       setRowError((e) => ({ ...e, [key]: err instanceof Error ? err.message : "save failed" }));
@@ -111,18 +119,20 @@ export default function ExperimentSettings({ settings, isLoading, error, onSaved
   const renderControl = (k: ExperimentSetting) => {
     const busy = !!saving[k.key];
     if (k.type === "bool") {
-      return <Toggle on={k.value === true} disabled={busy} onClick={() => save(k.key, !(k.value === true))} />;
+      return <Toggle on={k.value === true} disabled={busy} label={k.label} onClick={() => save(k.key, !(k.value === true))} />;
     }
     const draftKey = k.key;
     const current = drafts[draftKey] ?? String(k.value);
     const commit = () => {
       if (k.type === "int") {
-        const n = Number(current);
-        if (!Number.isFinite(n) || n < 0) {
-          setRowError((e) => ({ ...e, [k.key]: "must be a non-negative number" }));
+        // Treat blank as invalid rather than letting Number("") coerce to 0 and
+        // silently persist 0 on blur.
+        if (current.trim() === "" || !Number.isInteger(Number(current)) || Number(current) < 0) {
+          setRowError((e) => ({ ...e, [k.key]: "must be a non-negative integer" }));
           return;
         }
-        if (n !== k.value) save(k.key, Math.floor(n));
+        const n = Number(current);
+        if (n !== k.value) save(k.key, n);
       } else {
         if (current !== k.value) save(k.key, current);
       }

--- a/src/components/ExperimentSettings.tsx
+++ b/src/components/ExperimentSettings.tsx
@@ -1,0 +1,200 @@
+import { useState, type CSSProperties } from "react";
+import {
+  updateExperimentSetting,
+  type ExperimentSetting,
+  type ExperimentSettingsResponse,
+} from "../api/client";
+
+interface Props {
+  settings: ExperimentSettingsResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  onSaved: () => void;
+}
+
+const card: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  padding: "1rem 1.1rem",
+};
+
+const sectionLabel: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.6rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "#8890a0",
+  marginBottom: "0.6rem",
+};
+
+const knobRow: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr auto",
+  gap: "0.75rem",
+  alignItems: "center",
+  padding: "0.55rem 0",
+  borderBottom: "1px solid #ffffff08",
+};
+
+const knobLabel: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.78rem",
+  color: "var(--text-primary)",
+};
+
+const knobDesc: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.62rem",
+  color: "var(--text-muted)",
+  marginTop: "0.15rem",
+  maxWidth: "44rem",
+  lineHeight: 1.35,
+};
+
+function Toggle({ on, disabled, onClick }: { on: boolean; disabled: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      disabled={disabled}
+      onClick={onClick}
+      style={{
+        width: 40,
+        height: 22,
+        borderRadius: 11,
+        border: "1px solid #ffffff14",
+        background: on ? "var(--accent-success, #20e070)" : "#ffffff12",
+        position: "relative",
+        cursor: disabled ? "wait" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        transition: "background 0.15s",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          top: 2,
+          left: on ? 20 : 2,
+          width: 16,
+          height: 16,
+          borderRadius: "50%",
+          background: "#fff",
+          transition: "left 0.15s",
+        }}
+      />
+    </button>
+  );
+}
+
+export default function ExperimentSettings({ settings, isLoading, error, onSaved }: Props) {
+  // Per-key in-flight + error state, so one row's save doesn't block others.
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [rowError, setRowError] = useState<Record<string, string>>({});
+  // Local text buffer for int/string inputs so typing doesn't fight re-renders.
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+
+  const save = async (key: string, value: boolean | number | string) => {
+    setSaving((s) => ({ ...s, [key]: true }));
+    setRowError((e) => ({ ...e, [key]: "" }));
+    try {
+      await updateExperimentSetting(key, value);
+      onSaved();
+    } catch (err) {
+      setRowError((e) => ({ ...e, [key]: err instanceof Error ? err.message : "save failed" }));
+    } finally {
+      setSaving((s) => ({ ...s, [key]: false }));
+    }
+  };
+
+  const renderControl = (k: ExperimentSetting) => {
+    const busy = !!saving[k.key];
+    if (k.type === "bool") {
+      return <Toggle on={k.value === true} disabled={busy} onClick={() => save(k.key, !(k.value === true))} />;
+    }
+    const draftKey = k.key;
+    const current = drafts[draftKey] ?? String(k.value);
+    const commit = () => {
+      if (k.type === "int") {
+        const n = Number(current);
+        if (!Number.isFinite(n) || n < 0) {
+          setRowError((e) => ({ ...e, [k.key]: "must be a non-negative number" }));
+          return;
+        }
+        if (n !== k.value) save(k.key, Math.floor(n));
+      } else {
+        if (current !== k.value) save(k.key, current);
+      }
+    };
+    return (
+      <input
+        type={k.type === "int" ? "number" : "text"}
+        min={k.type === "int" ? 0 : undefined}
+        value={current}
+        disabled={busy}
+        onChange={(e) => setDrafts((d) => ({ ...d, [draftKey]: e.target.value }))}
+        onBlur={commit}
+        onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+        style={{
+          width: k.type === "int" ? 80 : 200,
+          background: "#ffffff08",
+          border: "1px solid #ffffff14",
+          borderRadius: "var(--radius-sm)",
+          color: "var(--text-primary)",
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.72rem",
+          padding: "0.3rem 0.5rem",
+        }}
+      />
+    );
+  };
+
+  if (isLoading && !settings) {
+    return <div style={{ ...card, color: "var(--text-muted)", fontFamily: "var(--font-mono)", fontSize: "0.7rem" }}>Loading settings…</div>;
+  }
+  if (error) {
+    return <div style={{ ...card, color: "var(--accent-danger, #ff4060)", fontFamily: "var(--font-mono)", fontSize: "0.7rem" }}>{error}</div>;
+  }
+  if (!settings) return null;
+
+  const applyMins = Math.round(settings.applyDelaySeconds / 60);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.9rem" }}>
+      <div style={card}>
+        <div style={sectionLabel}>Automation controls</div>
+        <div style={{ ...knobDesc, marginTop: 0, marginBottom: "0.5rem" }}>
+          Changes are saved immediately but workers may take up to ~{applyMins} min to pick them up (settings cache).
+        </div>
+        {settings.editable.map((k) => (
+          <div key={k.key} style={knobRow}>
+            <div>
+              <div style={knobLabel}>{k.label}</div>
+              <div style={knobDesc}>{k.description}</div>
+              {rowError[k.key] && (
+                <div style={{ ...knobDesc, color: "var(--accent-danger, #ff4060)" }}>{rowError[k.key]}</div>
+              )}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", justifySelf: "end" }}>
+              {renderControl(k)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={card}>
+        <div style={sectionLabel}>Algorithm parameters (read-only)</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(15rem, 1fr))", gap: "0.6rem" }}>
+          {settings.readOnly.map((c) => (
+            <div key={c.label} style={{ borderLeft: "2px solid #ffffff14", paddingLeft: "0.6rem" }}>
+              <div style={{ fontFamily: "var(--font-mono)", fontSize: "0.95rem", color: "var(--accent-primary)" }}>{c.value}</div>
+              <div style={{ fontFamily: "var(--font-sans)", fontSize: "0.68rem", color: "var(--text-secondary)", marginTop: "0.1rem" }}>{c.label}</div>
+              <div style={{ ...knobDesc, marginTop: "0.15rem" }}>{c.description}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ExperimentsOverview.tsx
+++ b/src/components/ExperimentsOverview.tsx
@@ -276,24 +276,35 @@ function ExperimentTimeSeries({ challenger, control, startMs, endMs }: { challen
         if (cancelled) return;
         const cb = extractTrackSeries(cbResp);
         const ex = extractTrackSeries(exResp);
-        // success rate per (track, ts) = callbacks / (callbacks + expired)
-        const expiredByTrackTs = new Map<string, Map<number, number>>();
-        for (const s of ex) {
-          const m = new Map<number, number>();
-          for (const p of s.points) m.set(p.ts, p.value);
-          expiredByTrackTs.set(s.key, m);
-        }
+        // success rate per (track, ts) = callbacks / (callbacks + expired).
+        // Index both series by track→ts→count and union them, so a track with
+        // only expired probes (zero successful callbacks) — the failing-challenger
+        // case the chart exists to surface — still renders a 0% line.
+        const index = (series: TrackSeries[]) => {
+          const m = new Map<string, Map<number, number>>();
+          for (const s of series) {
+            const ts = m.get(s.key) ?? new Map<number, number>();
+            for (const p of s.points) ts.set(p.ts, p.value);
+            m.set(s.key, ts);
+          }
+          return m;
+        };
+        const cbByTrackTs = index(cb);
+        const exByTrackTs = index(ex);
+        const seenKeys = new Set<string>([...cbByTrackTs.keys(), ...exByTrackTs.keys()]);
+
         const byTs = new Map<number, Record<string, number>>();
-        const seenKeys = new Set<string>();
-        for (const s of cb) {
-          seenKeys.add(s.key);
-          const exMap = expiredByTrackTs.get(s.key);
-          for (const p of s.points) {
-            const expired = exMap?.get(p.ts) ?? 0;
-            const denom = p.value + expired;
-            const rate = denom > 0 ? (p.value / denom) * 100 : 0;
-            if (!byTs.has(p.ts)) byTs.set(p.ts, { ts: p.ts });
-            byTs.get(p.ts)![s.key] = +rate.toFixed(1);
+        for (const key of seenKeys) {
+          const cbTs = cbByTrackTs.get(key);
+          const exTs = exByTrackTs.get(key);
+          const timestamps = new Set<number>([...(cbTs?.keys() ?? []), ...(exTs?.keys() ?? [])]);
+          for (const ts of timestamps) {
+            const callbacks = cbTs?.get(ts) ?? 0;
+            const expired = exTs?.get(ts) ?? 0;
+            const denom = callbacks + expired;
+            const rate = denom > 0 ? (callbacks / denom) * 100 : 0;
+            if (!byTs.has(ts)) byTs.set(ts, { ts });
+            byTs.get(ts)![key] = +rate.toFixed(1);
           }
         }
         setRows(Array.from(byTs.values()).sort((a, b) => a.ts - b.ts));

--- a/src/components/ExperimentsOverview.tsx
+++ b/src/components/ExperimentsOverview.tsx
@@ -1,0 +1,494 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  buildExperimentTrackQuery,
+  fetchSigNozMetrics,
+  type ExperimentDetail,
+  type ExperimentStratum,
+  type ExperimentSummary,
+  type ExperimentPipeline,
+} from "../api/client";
+import { useExperiments, useExperimentDetail, useExperimentSettings } from "../hooks/useExperiments";
+import { useAuth } from "../hooks/useAuth";
+import ExperimentSettings from "./ExperimentSettings";
+
+const CHALLENGER_COLOR = "#00e5c8";
+const CONTROL_COLOR = "#f0a030";
+
+// Lifecycle status → display color, matching the dashboard's accent palette.
+const STATUS_COLORS: Record<string, string> = {
+  proposed: "#667080",
+  provisioning: "#80b0e0",
+  gathering: "#f0a030",
+  deciding: "#c090e0",
+  promoting: "#60c0d0",
+  promoted: "#20e070",
+  retiring: "#e0a060",
+  retired: "#8890a0",
+  aborted: "#ff4060",
+};
+
+const VERDICT_COLORS: Record<string, string> = {
+  promote: "#20e070",
+  retire: "#ff4060",
+  hold: "#8890a0",
+};
+
+const card: CSSProperties = {
+  background: "var(--bg-card)",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid #ffffff08",
+  padding: "1rem 1.1rem",
+};
+
+const sectionLabel: CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.6rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "#8890a0",
+  marginBottom: "0.6rem",
+};
+
+const mono: CSSProperties = { fontFamily: "var(--font-mono)", fontSize: "0.7rem" };
+
+function formatBytesPerSec(v: number): string {
+  if (!v || v <= 0) return "0";
+  const units = ["B/s", "KB/s", "MB/s", "GB/s"];
+  let i = 0;
+  let n = v;
+  while (n >= 1024 && i < units.length - 1) { n /= 1024; i++; }
+  return `${n.toFixed(n >= 100 ? 0 : 1)} ${units[i]}`;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const color = STATUS_COLORS[status] || "#8890a0";
+  return (
+    <span style={{
+      ...mono, fontSize: "0.55rem", textTransform: "uppercase", letterSpacing: "0.05em",
+      padding: "0.1rem 0.4rem", borderRadius: "3px",
+      color, background: `${color}1a`, border: `1px solid ${color}40`,
+    }}>{status}</span>
+  );
+}
+
+// ── Lifecycle pipeline strip ──
+
+function PipelineStrip({ pipeline }: { pipeline: ExperimentPipeline | null }) {
+  if (!pipeline) return null;
+  return (
+    <div style={card}>
+      <div style={sectionLabel}>Lifecycle pipeline</div>
+      <div style={{ display: "flex", gap: "0.4rem", flexWrap: "wrap" }}>
+        {pipeline.order.map((status) => {
+          const count = pipeline.counts[status] ?? 0;
+          const color = STATUS_COLORS[status] || "#8890a0";
+          const active = count > 0;
+          return (
+            <div key={status} style={{
+              flex: "1 1 6rem", minWidth: "5.5rem",
+              borderRadius: "var(--radius-sm)",
+              border: `1px solid ${active ? `${color}40` : "#ffffff0d"}`,
+              background: active ? `${color}12` : "#ffffff05",
+              padding: "0.5rem 0.6rem",
+            }}>
+              <div style={{ ...mono, fontSize: "1.3rem", fontWeight: 600, color: active ? color : "#5a6472" }}>{count}</div>
+              <div style={{ ...mono, fontSize: "0.5rem", textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--text-muted)" }}>{status}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Per-stratum comparison charts ──
+
+function StrataCharts({ strata, challenger, control }: { strata: ExperimentStratum[]; challenger: string; control: string }) {
+  const goodputData = strata.map((s) => ({ country: s.country, challenger: s.challengerGoodput, control: s.controlGoodput, qualifies: s.qualifies }));
+  const successData = strata.map((s) => ({ country: s.country, challenger: +(s.challengerSuccessRate * 100).toFixed(1), control: +(s.controlSuccessRate * 100).toFixed(1) }));
+
+  if (strata.length === 0) {
+    return <div style={{ ...mono, color: "var(--text-muted)" }}>No per-country strata yet for this window.</div>;
+  }
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(20rem, 1fr))", gap: "1rem" }}>
+      <div>
+        <div style={{ ...mono, fontSize: "0.6rem", color: "var(--text-secondary)", marginBottom: "0.3rem" }}>Median goodput by country</div>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={goodputData} margin={{ top: 8, right: 8, bottom: 4, left: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
+            <XAxis dataKey="country" tick={{ fontSize: 10, fill: "#8890a0" }} />
+            <YAxis tick={{ fontSize: 10, fill: "#8890a0" }} tickFormatter={formatBytesPerSec} width={64} />
+            <Tooltip formatter={(v) => formatBytesPerSec(Number(v))} contentStyle={{ background: "var(--bg-secondary)", border: "1px solid #ffffff14", fontSize: 11 }} />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+            <Bar name={`${challenger} (challenger)`} dataKey="challenger" fill={CHALLENGER_COLOR} />
+            <Bar name={`${control} (control)`} dataKey="control" fill={CONTROL_COLOR} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <div>
+        <div style={{ ...mono, fontSize: "0.6rem", color: "var(--text-secondary)", marginBottom: "0.3rem" }}>Success rate by country (%)</div>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={successData} margin={{ top: 8, right: 8, bottom: 4, left: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
+            <XAxis dataKey="country" tick={{ fontSize: 10, fill: "#8890a0" }} />
+            <YAxis domain={[0, 100]} tick={{ fontSize: 10, fill: "#8890a0" }} width={36} />
+            <Tooltip formatter={(v) => `${Number(v)}%`} contentStyle={{ background: "var(--bg-secondary)", border: "1px solid #ffffff14", fontSize: 11 }} />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+            <Bar name={`${challenger} (challenger)`} dataKey="challenger" fill={CHALLENGER_COLOR} />
+            <Bar name={`${control} (control)`} dataKey="control" fill={CONTROL_COLOR} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+// ── Decision + guardrail cards ──
+
+function DecisionCard({ detail }: { detail: ExperimentDetail }) {
+  const d = detail.decisionPreview;
+  const color = VERDICT_COLORS[d.verdict] || "#8890a0";
+  return (
+    <div style={{ ...card, flex: "1 1 16rem" }}>
+      <div style={sectionLabel}>Decision preview</div>
+      <div style={{ ...mono, fontSize: "1.1rem", fontWeight: 600, color, textTransform: "uppercase" }}>{d.verdict || "—"}</div>
+      <div style={{ ...mono, fontSize: "0.62rem", color: "var(--text-secondary)", marginTop: "0.25rem", lineHeight: 1.4 }}>{d.reason}</div>
+      <div style={{ display: "flex", gap: "1rem", marginTop: "0.6rem", flexWrap: "wrap" }}>
+        <Stat label="Qualifying strata" value={`${d.qualifyingStrata} / ${d.minStrata}`} ok={d.qualifyingStrata >= d.minStrata} />
+        <Stat label="Wins" value={String(d.wins)} />
+        <Stat label="Losses" value={String(d.losses)} />
+        <Stat label="Win margin" value={`${Math.round(d.winMargin * 100)}%`} />
+      </div>
+    </div>
+  );
+}
+
+function GuardrailsCard({ detail }: { detail: ExperimentDetail }) {
+  const g = detail.guardrails;
+  return (
+    <div style={{ ...card, flex: "1 1 16rem" }}>
+      <div style={sectionLabel}>Reliability guardrails</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.55rem" }}>
+        <GuardrailRow
+          name="Blocking"
+          ok={g.blockingOk}
+          detail={`${g.blockedRoutes}/${g.totalRoutes} routes blocked (veto ≥ ${Math.round(g.maxBlockedFraction * 100)}%)`}
+          reason={g.blockingReason}
+        />
+        <GuardrailRow
+          name="Success rate"
+          ok={g.successOk}
+          detail={g.successReason || "challenger not materially below control"}
+          reason={g.successOk ? undefined : g.successReason}
+        />
+      </div>
+    </div>
+  );
+}
+
+function GuardrailRow({ name, ok, detail, reason }: { name: string; ok: boolean; detail: string; reason?: string }) {
+  const color = ok ? "#20e070" : "#ff4060";
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <span style={{ width: 8, height: 8, borderRadius: "50%", background: color, display: "inline-block" }} />
+        <span style={{ ...mono, fontSize: "0.72rem", color: "var(--text-primary)" }}>{name}</span>
+        <span style={{ ...mono, fontSize: "0.55rem", color, textTransform: "uppercase" }}>{ok ? "pass" : "veto"}</span>
+      </div>
+      <div style={{ ...mono, fontSize: "0.58rem", color: "var(--text-muted)", marginLeft: "1rem", marginTop: "0.1rem" }}>{reason || detail}</div>
+    </div>
+  );
+}
+
+function Stat({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div>
+      <div style={{ ...mono, fontSize: "0.95rem", fontWeight: 600, color: ok === undefined ? "var(--text-primary)" : ok ? "#20e070" : "#e0a060" }}>{value}</div>
+      <div style={{ ...mono, fontSize: "0.5rem", textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--text-muted)" }}>{label}</div>
+    </div>
+  );
+}
+
+// ── Time-series: success rate over the gathering window (SigNoz) ──
+
+interface TrackSeries { key: string; points: Array<{ ts: number; value: number }>; }
+
+function extractTrackSeries(resp: unknown): TrackSeries[] {
+  const out: TrackSeries[] = [];
+  const r = resp as { data?: { result?: Array<{ series?: Array<{ labels?: Record<string, string>; values?: Array<{ timestamp?: number | string; value?: number | string }> }> }> } };
+  for (const qr of r?.data?.result ?? []) {
+    for (const s of qr.series ?? []) {
+      const label = s.labels?.track || s.labels?.["proxy.track"];
+      if (!label) continue;
+      const points = (s.values ?? [])
+        .map((v) => ({ ts: Number(v.timestamp) || 0, value: Number(v.value) || 0 }))
+        .filter((p) => p.ts > 0)
+        .sort((a, b) => a.ts - b.ts);
+      if (points.length > 0) out.push({ key: label, points });
+    }
+  }
+  return out;
+}
+
+function ExperimentTimeSeries({ challenger, control, startMs, endMs }: { challenger: string; control: string; startMs: number; endMs: number }) {
+  const { isAuthenticated } = useAuth();
+  const [rows, setRows] = useState<Array<Record<string, number>>>([]);
+  const [keys, setKeys] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const tracks = useMemo(() => [challenger, control].filter(Boolean), [challenger, control]);
+
+  useEffect(() => {
+    if (!isAuthenticated || tracks.length === 0 || !(endMs > startMs)) return;
+    let cancelled = false;
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+
+      const windowSec = (endMs - startMs) / 1000;
+      const stepSeconds = Math.max(300, Math.round(windowSec / 200));
+      const mk = (metric: string) => buildExperimentTrackQuery({
+        metricName: metric, trackNames: tracks, trackKey: "track",
+        timeAggregation: "rate", spaceAggregation: "sum", startMs, endMs, stepSeconds,
+      });
+
+      try {
+        const [cbResp, exResp] = await Promise.all([
+          fetchSigNozMetrics(mk("bandit.callbacks")),
+          fetchSigNozMetrics(mk("bandit.probes_expired")),
+        ]);
+        if (cancelled) return;
+        const cb = extractTrackSeries(cbResp);
+        const ex = extractTrackSeries(exResp);
+        // success rate per (track, ts) = callbacks / (callbacks + expired)
+        const expiredByTrackTs = new Map<string, Map<number, number>>();
+        for (const s of ex) {
+          const m = new Map<number, number>();
+          for (const p of s.points) m.set(p.ts, p.value);
+          expiredByTrackTs.set(s.key, m);
+        }
+        const byTs = new Map<number, Record<string, number>>();
+        const seenKeys = new Set<string>();
+        for (const s of cb) {
+          seenKeys.add(s.key);
+          const exMap = expiredByTrackTs.get(s.key);
+          for (const p of s.points) {
+            const expired = exMap?.get(p.ts) ?? 0;
+            const denom = p.value + expired;
+            const rate = denom > 0 ? (p.value / denom) * 100 : 0;
+            if (!byTs.has(p.ts)) byTs.set(p.ts, { ts: p.ts });
+            byTs.get(p.ts)![s.key] = +rate.toFixed(1);
+          }
+        }
+        setRows(Array.from(byTs.values()).sort((a, b) => a.ts - b.ts));
+        setKeys(Array.from(seenKeys));
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load time-series");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+    return () => { cancelled = true; };
+  }, [tracks, startMs, endMs, isAuthenticated]);
+
+  if (error) return <div style={{ ...mono, fontSize: "0.6rem", color: "var(--text-muted)" }}>Time-series unavailable: {error}</div>;
+  if (loading && rows.length === 0) return <div style={{ ...mono, fontSize: "0.6rem", color: "var(--text-muted)" }}>Loading time-series…</div>;
+  if (rows.length === 0) return <div style={{ ...mono, fontSize: "0.6rem", color: "var(--text-muted)" }}>No probe activity in this window.</div>;
+
+  const colorFor = (k: string) => (k === challenger ? CHALLENGER_COLOR : CONTROL_COLOR);
+  return (
+    <div>
+      <div style={{ ...mono, fontSize: "0.6rem", color: "var(--text-secondary)", marginBottom: "0.3rem" }}>Probe success rate over time (%)</div>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={rows} margin={{ top: 8, right: 8, bottom: 4, left: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" />
+          <XAxis dataKey="ts" type="number" domain={["dataMin", "dataMax"]} scale="time"
+            tickFormatter={(ts: number) => new Date(ts).toLocaleDateString([], { month: "short", day: "numeric" })}
+            tick={{ fontSize: 10, fill: "#8890a0" }} />
+          <YAxis domain={[0, 100]} tick={{ fontSize: 10, fill: "#8890a0" }} width={36} />
+          <Tooltip
+            formatter={(v) => `${Number(v)}%`}
+            labelFormatter={(ts) => new Date(Number(ts)).toLocaleString()}
+            contentStyle={{ background: "var(--bg-secondary)", border: "1px solid #ffffff14", fontSize: 11 }} />
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          {keys.map((k) => (
+            <Line key={k} type="monotone" dataKey={k} name={k === challenger ? `${k} (challenger)` : k === control ? `${k} (control)` : k}
+              stroke={colorFor(k)} dot={false} strokeWidth={2} isAnimationActive={false} />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ── Detail panel (loaded on row expand) ──
+
+function ExperimentDetailPanel({ id }: { id: number }) {
+  const { detail, isLoading, error } = useExperimentDetail(id);
+
+  if (isLoading && !detail) return <div style={{ ...mono, color: "var(--text-muted)", padding: "0.75rem" }}>Loading stats…</div>;
+  if (error) return <div style={{ ...mono, color: "var(--accent-danger, #ff4060)", padding: "0.75rem" }}>{error}</div>;
+  if (!detail) return null;
+
+  const challenger = detail.challengerTrackName || "challenger";
+  const control = detail.controlTrackName || "control";
+  const startMs = detail.windowStart ? Date.parse(detail.windowStart) : 0;
+  const endMs = detail.windowEnd ? Date.parse(detail.windowEnd) : 0;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.9rem", padding: "0.75rem 0.25rem" }}>
+      {detail.statsError && (
+        <div style={{ ...mono, fontSize: "0.62rem", color: "#e0a060", background: "#f0a03012", border: "1px solid #f0a03030", borderRadius: "var(--radius-sm)", padding: "0.5rem 0.7rem" }}>
+          {detail.statsError}
+        </div>
+      )}
+      <div style={{ display: "flex", gap: "0.9rem", flexWrap: "wrap" }}>
+        <DecisionCard detail={detail} />
+        <GuardrailsCard detail={detail} />
+      </div>
+      <div style={card}>
+        <div style={sectionLabel}>Per-country strata — challenger vs control</div>
+        <StrataCharts strata={detail.strata ?? []} challenger={challenger} control={control} />
+      </div>
+      {startMs > 0 && endMs > startMs && (
+        <div style={card}>
+          <div style={sectionLabel}>Time-series</div>
+          <ExperimentTimeSeries challenger={challenger} control={control} startMs={startMs} endMs={endMs} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Experiments table ──
+
+const colTemplate = "3rem 7rem 1fr 1fr 0.8fr 1fr 0.8fr";
+
+function ExperimentsTable({ experiments, selectedId, onSelect }: {
+  experiments: ExperimentSummary[]; selectedId: number | null; onSelect: (id: number | null) => void;
+}) {
+  if (experiments.length === 0) {
+    return <div style={{ ...mono, color: "var(--text-muted)", padding: "1rem" }}>No experiments yet.</div>;
+  }
+  const headerStyle: CSSProperties = {
+    display: "grid", gridTemplateColumns: colTemplate, gap: "0.5rem",
+    padding: "0.4rem 0.75rem", ...mono, fontSize: "0.55rem", textTransform: "uppercase",
+    letterSpacing: "0.05em", color: "var(--text-muted)", borderBottom: "1px solid #ffffff10",
+  };
+  return (
+    <div style={card}>
+      <div style={sectionLabel}>Experiments</div>
+      <div style={headerStyle}>
+        <div>ID</div><div>Status</div><div>Region / Location</div><div>Challenger → Control</div><div>Protocol</div><div>Decision</div><div>Gathering</div>
+      </div>
+      {experiments.map((e) => {
+        const expanded = selectedId === e.id;
+        return (
+          <div key={e.id}>
+            <div
+              onClick={() => onSelect(expanded ? null : e.id)}
+              style={{
+                display: "grid", gridTemplateColumns: colTemplate, gap: "0.5rem", alignItems: "center",
+                padding: "0.5rem 0.75rem", ...mono, fontSize: "0.65rem", cursor: "pointer",
+                background: expanded ? "#ffffff08" : "transparent",
+                borderBottom: "1px solid #ffffff08",
+              }}
+            >
+              <div style={{ color: "var(--text-muted)" }}>#{e.id}</div>
+              <div><StatusBadge status={e.status} /></div>
+              <div style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                <span style={{ color: "var(--text-primary)" }}>{e.regionName || `r${e.regionId}`}</span>
+                <span style={{ color: "var(--text-muted)" }}> / {e.locationName || "—"}{e.providerName ? ` (${e.providerName})` : ""}</span>
+              </div>
+              <div style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                <span style={{ color: CHALLENGER_COLOR }}>{e.challengerTrackName || "—"}</span>
+                <span style={{ color: "var(--text-muted)" }}> → </span>
+                <span style={{ color: CONTROL_COLOR }}>{e.controlTrackName || "—"}</span>
+              </div>
+              <div style={{ color: "var(--text-secondary)" }}>{e.protocolName || "—"}</div>
+              <div style={{ color: e.decision === "promote" ? "#20e070" : e.decision === "retire" ? "#ff4060" : "var(--text-muted)" }}>
+                {e.decision || "—"}
+              </div>
+              <div style={{ color: "var(--text-secondary)" }}>{e.gatheringHours ? `${e.gatheringHours.toFixed(0)}h` : "—"}</div>
+            </div>
+            {expanded && <ExperimentDetailPanel id={e.id} />}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Top-level tab content ──
+
+export default function ExperimentsOverview({ enabled }: { enabled: boolean }) {
+  const [view, setView] = useState<"experiments" | "settings">("experiments");
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const { experiments, pipeline, isLoading, hasLoaded, error } = useExperiments(enabled);
+  const settings = useExperimentSettings(enabled);
+
+  // Surface a banner when the core automation workers are paused.
+  const automationOff = useMemo(() => {
+    const ed = settings.settings?.editable ?? [];
+    const get = (k: string) => ed.find((s) => s.key === k)?.value === true;
+    if (ed.length === 0) return false;
+    return !(get("experiment_proposer_enabled") && get("experiment_evaluator_enabled"));
+  }, [settings.settings]);
+
+  const tabBtn = (v: "experiments" | "settings"): CSSProperties => ({
+    ...mono, fontSize: "0.6rem", padding: "0.25rem 0.7rem", borderRadius: "var(--radius-sm)",
+    cursor: "pointer", userSelect: "none", textTransform: "uppercase", letterSpacing: "0.05em",
+    background: view === v ? "var(--accent-primary-dim)" : "#ffffff08",
+    color: view === v ? "var(--accent-primary)" : "var(--text-muted)",
+    border: `1px solid ${view === v ? "#00e5c830" : "#ffffff10"}`,
+  });
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "0.75rem", overflowY: "auto", padding: "0.75rem" }}>
+      <div style={{ display: "flex", gap: "0.4rem", alignItems: "center" }}>
+        <div onClick={() => setView("experiments")} style={tabBtn("experiments")}>Experiments</div>
+        <div onClick={() => setView("settings")} style={tabBtn("settings")}>Settings</div>
+      </div>
+
+      {automationOff && view === "experiments" && (
+        <div style={{ ...mono, fontSize: "0.62rem", color: "#e0a060", background: "#f0a03012", border: "1px solid #f0a03030", borderRadius: "var(--radius-sm)", padding: "0.5rem 0.75rem" }}>
+          Automation is paused — the proposer and/or evaluator are disabled. Enable them in <span style={{ textDecoration: "underline", cursor: "pointer" }} onClick={() => setView("settings")}>Settings</span>.
+        </div>
+      )}
+
+      {view === "settings" ? (
+        <ExperimentSettings settings={settings.settings} isLoading={settings.isLoading} error={settings.error} onSaved={settings.reload} />
+      ) : (
+        <>
+          {error && (
+            <div style={{ ...mono, fontSize: "0.65rem", color: "var(--accent-danger, #ff4060)", background: "#ff406012", border: "1px solid #ff406030", borderRadius: "var(--radius-sm)", padding: "0.5rem 0.75rem" }}>{error}</div>
+          )}
+          <PipelineStrip pipeline={pipeline} />
+          {isLoading && !hasLoaded ? (
+            <div style={{ ...mono, color: "var(--text-muted)", padding: "1rem" }}>Loading experiments…</div>
+          ) : (
+            <ExperimentsTable experiments={experiments} selectedId={selectedId} onSelect={setSelectedId} />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -28,6 +28,17 @@ declare global {
 // 401 fallback treats it as a hard failure and logs out.
 const REFRESH_BUFFER_SECONDS = 5 * 60;
 const SILENT_REFRESH_TIMEOUT_MS = 10_000;
+
+// Dev-only auth bypass. When running the Vite dev server (import.meta.env.DEV)
+// with no Google client configured, there is no way to sign in — yet the data
+// hooks all gate on isAuthenticated, so the dashboard would render empty. In that
+// case we seed a throwaway dev session so the app behaves as authenticated. This
+// can never trigger in a production build (DEV is false) or whenever a real
+// VITE_GOOGLE_CLIENT_ID is set. The token is ignored by a local API run with
+// API_LOCAL=1 (which bypasses Google verification server-side).
+const DEV_AUTH_BYPASS = import.meta.env.DEV && !import.meta.env.VITE_GOOGLE_CLIENT_ID;
+const DEV_USER = { name: "Local Dev", email: "dev@getlantern.org", picture: "" };
+const DEV_TOKEN = "dev-local-bypass";
 // If a proactive refresh comes back empty (GIS momentarily unavailable), retry
 // on this interval until the token actually expires, rather than waiting for a
 // request to 401.
@@ -77,6 +88,10 @@ function isTokenExpired(token: string): boolean {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthState["user"]>(() => {
+    if (DEV_AUTH_BYPASS) {
+      setAuthToken(DEV_TOKEN);
+      return DEV_USER;
+    }
     const saved = localStorage.getItem("dashboard_user");
     if (saved) {
       const token = localStorage.getItem("dashboard_token");
@@ -92,6 +107,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   });
 
   const [token, setToken] = useState<string | null>(() => {
+    if (DEV_AUTH_BYPASS) return DEV_TOKEN;
     const t = localStorage.getItem("dashboard_token");
     return t && !isTokenExpired(t) ? t : null;
   });

--- a/src/hooks/useExperiments.ts
+++ b/src/hooks/useExperiments.ts
@@ -1,0 +1,113 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  fetchExperiments,
+  fetchExperimentDetail,
+  fetchExperimentSettings,
+  type ExperimentSummary,
+  type ExperimentPipeline,
+  type ExperimentDetail,
+  type ExperimentSettingsResponse,
+} from "../api/client";
+import { useAuth } from "./useAuth";
+
+// useExperiments polls the experiments list + pipeline every 30s while the tab is
+// active. Mirrors useVPSData's loading/error/hasLoaded contract.
+export function useExperiments(enabled: boolean) {
+  const { isAuthenticated } = useAuth();
+  const [experiments, setExperiments] = useState<ExperimentSummary[]>([]);
+  const [pipeline, setPipeline] = useState<ExperimentPipeline | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !isAuthenticated) return;
+    let cancelled = false;
+    let isFirst = true;
+
+    const refresh = async () => {
+      if (isFirst) setIsLoading(true);
+      try {
+        const data = await fetchExperiments();
+        if (cancelled) return;
+        setExperiments(data.experiments ?? []);
+        setPipeline(data.pipeline ?? null);
+        setError(null);
+        setHasLoaded(true);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load experiments");
+      } finally {
+        if (!cancelled && isFirst) setIsLoading(false);
+        isFirst = false;
+      }
+    };
+
+    refresh();
+    const interval = setInterval(refresh, 30000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [enabled, isAuthenticated]);
+
+  return { experiments, pipeline, isLoading, hasLoaded, error };
+}
+
+// useExperimentDetail fetches one experiment's full stats on demand (when a row is
+// expanded). Re-fetches whenever id changes; null id clears.
+export function useExperimentDetail(id: number | null) {
+  const [detail, setDetail] = useState<ExperimentDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      if (id == null) {
+        setDetail(null);
+        setError(null);
+        return;
+      }
+      setIsLoading(true);
+      setError(null);
+      try {
+        const d = await fetchExperimentDetail(id);
+        if (!cancelled) setDetail(d);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load detail");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    run();
+    return () => { cancelled = true; };
+  }, [id]);
+
+  return { detail, isLoading, error };
+}
+
+// useExperimentSettings loads the knob registry + read-only constants once, with a
+// reload callback used after a successful write.
+export function useExperimentSettings(enabled: boolean) {
+  const { isAuthenticated } = useAuth();
+  const [settings, setSettings] = useState<ExperimentSettingsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await fetchExperimentSettings();
+      setSettings(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load settings");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !isAuthenticated) return;
+    reload();
+  }, [enabled, isAuthenticated, reload]);
+
+  return { settings, setSettings, isLoading, error, reload };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,31 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import mkcert from 'vite-plugin-mkcert'
 
 // https://vite.dev/config/
+//
+// Local dev against a local lantern-cloud API (run with API_LOCAL=1, which serves
+// HTTPS on :8080 with a self-signed cert and bypasses Google auth). mkcert gives
+// the dev server a locally-trusted cert, and the proxy forwards the API paths to
+// the backend with `secure: false` so the browser never sees the self-signed cert
+// or a cross-origin request. To use it, point the app at the dev origin via
+// `VITE_API_URL=https://localhost:5173` (see .env.local).
+//
+// In production the app talks directly to the real API (VITE_API_URL = the
+// canonical prod/staging host), so this proxy is dev-only and inert.
+const API_TARGET = process.env.VITE_DEV_API_TARGET || 'https://localhost:8080'
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [mkcert(), react()],
+  server: {
+    proxy: {
+      // The dashboard backend lives under /v1; forward it (and the SSE stream)
+      // to the local API. `secure: false` accepts the API's self-signed cert.
+      '/v1': {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import mkcert from 'vite-plugin-mkcert'
 
@@ -13,19 +13,25 @@ import mkcert from 'vite-plugin-mkcert'
 //
 // In production the app talks directly to the real API (VITE_API_URL = the
 // canonical prod/staging host), so this proxy is dev-only and inert.
-const API_TARGET = process.env.VITE_DEV_API_TARGET || 'https://localhost:8080'
-
-export default defineConfig({
-  plugins: [mkcert(), react()],
-  server: {
-    proxy: {
-      // The dashboard backend lives under /v1; forward it (and the SSE stream)
-      // to the local API. `secure: false` accepts the API's self-signed cert.
-      '/v1': {
-        target: API_TARGET,
-        changeOrigin: true,
-        secure: false,
+//
+// Vite does not populate process.env from .env files when evaluating this config,
+// so read the optional override via loadEnv (which merges .env files + the real
+// environment) rather than process.env.
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const apiTarget = env.VITE_DEV_API_TARGET || 'https://localhost:8080'
+  return {
+    plugins: [mkcert(), react()],
+    server: {
+      proxy: {
+        // The dashboard backend lives under /v1; forward it (and the SSE stream)
+        // to the local API. `secure: false` accepts the API's self-signed cert.
+        '/v1': {
+          target: apiTarget,
+          changeOrigin: true,
+          secure: false,
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
## Summary

Adds an **Experiments** tab to the dashboard that visualizes the bandit experiments system (lantern-cloud [#2874](https://github.com/getlantern/lantern-cloud/pull/2874)) and exposes its tuning knobs. Pairs with the backend PR that adds the `/v1/dashboard/experiments*` endpoints.

Tracks **getlantern/engineering#3644**.

## What's included

**New Experiments tab** (`src/components/ExperimentsOverview.tsx`)
- Lifecycle **pipeline** strip with per-status counts (proposed → … → promoted/retired/aborted)
- **Experiments table** with resolved region/location/provider/protocol + challenger→control tracks, decision, gathering duration
- Row **drill-in**: per-country strata comparison (goodput + success rate bar charts), decision-preview card, reliability-guardrail cards, and a probe-success-rate time-series (via the existing SigNoz `/metrics` proxy)
- "Automation paused" banner when the proposer/evaluator are disabled

**Editable settings** (`src/components/ExperimentSettings.tsx`)
- Toggles/inputs for the 9 hot-reloadable knobs (writes persist to the settings DB)
- Read-only "Algorithm parameters" section (gamma/alpha, decision thresholds, guardrail margins, gathering windows)

**Data layer**
- `src/api/client.ts`: experiment types, `fetchExperiments`/`fetchExperimentDetail`/`fetchExperimentSettings`/`updateExperimentSetting`, and a SigNoz per-track query builder
- `src/hooks/useExperiments.ts`: list/detail/settings hooks (polling, mirrors `useVPSData`)

**Overview tab** (`src/components/BanditArmsOverview.tsx`)
- New "Automatic experiments" section with a lifecycle diagram + explanation (proposer/realizer/evaluator, big-win rule, guardrails, staged promotion)

**Dev-only local setup** (does not affect production builds)
- `vite.config.ts`: `vite-plugin-mkcert` + a `/v1` proxy to a local API (`secure: false`), mirroring `cmd/backoffice`
- `useAuth.tsx`: a dev-only auth bypass, gated on `import.meta.env.DEV && !VITE_GOOGLE_CLIENT_ID`, so the no-OAuth dev mode renders as authenticated and the data hooks fire

## Testing
- `npm run build` (tsc + vite) passes; lint clean for new files
- Verified end-to-end against a local `API_LOCAL=1` lantern-cloud API with seeded experiments: pipeline, table, drill-in cards, and settings round-trip all render/work

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Experiments** dashboard area with experiment lists, details, decision previews, guardrails, and trend charts.
  * Added an **Experiment Settings** screen for viewing and updating editable experiment controls.
  * Expanded the “How it works” content with an **Automatic experiments** section and lifecycle diagram.
* **Bug Fixes**
  * Improved experiment data loading and refresh behavior, including clearer error handling and retry support for updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->