### PR TITLE
experiments: per-experiment Abort/Retire operator actions

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -749,6 +749,44 @@ export async function updateExperimentSetting(
   return res.json();
 }
 
+// terminateExperiment POSTs an abort/retire action for one experiment. Like
+// updateExperimentSetting it can't use apiFetch (GET-only) and reuses the 401
+// retry handler manually. The backend drives experiment.TerminateByID — the same
+// teardown the `lc experiments` CLI uses — and returns the updated summary.
+async function terminateExperiment(
+  action: "abort" | "retire",
+  id: number,
+  reason: string,
+): Promise<ExperimentSummary> {
+  const url = `${getApiUrl()}/v1/dashboard/experiments/${action}`;
+  const send = (token: string | null) => {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return fetch(url, { method: "POST", headers, body: JSON.stringify({ id, reason }) });
+  };
+  let res = await send(authToken);
+  if (res.status === 401 && onAuthExpired) {
+    const newToken = await onAuthExpired();
+    if (newToken) {
+      authToken = newToken;
+      res = await send(newToken);
+    }
+  }
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`${action} failed: ${res.status} ${body}`);
+  }
+  return res.json();
+}
+
+export function abortExperiment(id: number, reason: string): Promise<ExperimentSummary> {
+  return terminateExperiment("abort", id, reason);
+}
+
+export function retireExperiment(id: number, reason: string): Promise<ExperimentSummary> {
+  return terminateExperiment("retire", id, reason);
+}
+
 // buildExperimentTrackQuery builds a SigNoz v5 builder query for a metric grouped
 // by track, filtered to a set of track names — used to chart a single experiment's
 // challenger vs control over time. trackKey differs by metric: the bandit probe

--- a/src/components/ExperimentsOverview.tsx
+++ b/src/components/ExperimentsOverview.tsx
@@ -12,8 +12,10 @@ import {
   YAxis,
 } from "recharts";
 import {
+  abortExperiment,
   buildExperimentTrackQuery,
   fetchSigNozMetrics,
+  retireExperiment,
   type ExperimentDetail,
   type ExperimentStratum,
   type ExperimentSummary,
@@ -44,6 +46,11 @@ const VERDICT_COLORS: Record<string, string> = {
   retire: "#ff4060",
   hold: "#8890a0",
 };
+
+// Terminal lifecycle states — an experiment here is already torn down (or
+// promoted), so the operator abort/retire actions are hidden. Mirrors the
+// experiment package's terminalStatuses.
+const TERMINAL_STATUSES = new Set(["promoted", "retired", "aborted"]);
 
 const card: CSSProperties = {
   background: "var(--bg-card)",
@@ -350,9 +357,62 @@ function ExperimentTimeSeries({ challenger, control, startMs, endMs }: { challen
   );
 }
 
+// ── Operator actions (abort / retire) ──
+
+function ExperimentActions({ id, status, onChanged }: { id: number; status: string; onChanged: () => void }) {
+  const [busy, setBusy] = useState<"abort" | "retire" | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Already terminal — nothing left to tear down.
+  if (TERMINAL_STATUSES.has(status)) return null;
+
+  const run = async (action: "abort" | "retire") => {
+    const reason = window.prompt(
+      `${action === "abort" ? "Abort" : "Retire"} experiment #${id}?\n\n` +
+        "This disables its challenger track, zeroes its VPS pool, and deprecates its routes.\n\n" +
+        "Optional reason (recorded as the experiment's decision reason). Click Cancel to back out.",
+      "",
+    );
+    if (reason === null) return; // operator cancelled
+    setBusy(action);
+    setErr(null);
+    setMsg(null);
+    try {
+      const updated = action === "abort" ? await abortExperiment(id, reason) : await retireExperiment(id, reason);
+      setMsg(`Experiment #${updated.id} is now ${updated.status}.`);
+      onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : `Failed to ${action}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const btn = (color: string): CSSProperties => ({
+    ...mono, fontSize: "0.6rem", textTransform: "uppercase", letterSpacing: "0.05em",
+    padding: "0.3rem 0.8rem", borderRadius: "var(--radius-sm)", cursor: busy ? "default" : "pointer",
+    color, background: `${color}14`, border: `1px solid ${color}40`, opacity: busy ? 0.6 : 1,
+  });
+
+  return (
+    <div style={{ ...card, display: "flex", alignItems: "center", gap: "0.6rem", flexWrap: "wrap" }}>
+      <div style={{ ...sectionLabel, marginBottom: 0 }}>Operator actions</div>
+      <button type="button" disabled={busy !== null} style={btn("#ff4060")} onClick={() => run("abort")}>
+        {busy === "abort" ? "Aborting…" : "Abort"}
+      </button>
+      <button type="button" disabled={busy !== null} style={btn("#e0a060")} onClick={() => run("retire")}>
+        {busy === "retire" ? "Retiring…" : "Retire"}
+      </button>
+      {msg && <span style={{ ...mono, fontSize: "0.6rem", color: "#20e070" }}>{msg}</span>}
+      {err && <span style={{ ...mono, fontSize: "0.6rem", color: "#ff4060" }}>{err}</span>}
+    </div>
+  );
+}
+
 // ── Detail panel (loaded on row expand) ──
 
-function ExperimentDetailPanel({ id }: { id: number }) {
+function ExperimentDetailPanel({ id, status, onChanged }: { id: number; status: string; onChanged: () => void }) {
   const { detail, isLoading, error } = useExperimentDetail(id);
 
   if (isLoading && !detail) return <div style={{ ...mono, color: "var(--text-muted)", padding: "0.75rem" }}>Loading stats…</div>;
@@ -366,6 +426,7 @@ function ExperimentDetailPanel({ id }: { id: number }) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "0.9rem", padding: "0.75rem 0.25rem" }}>
+      <ExperimentActions id={id} status={detail.status || status} onChanged={onChanged} />
       {detail.statsError && (
         <div style={{ ...mono, fontSize: "0.62rem", color: "#e0a060", background: "#f0a03012", border: "1px solid #f0a03030", borderRadius: "var(--radius-sm)", padding: "0.5rem 0.7rem" }}>
           {detail.statsError}
@@ -393,8 +454,8 @@ function ExperimentDetailPanel({ id }: { id: number }) {
 
 const colTemplate = "3rem 7rem 1fr 1fr 0.8fr 1fr 0.8fr";
 
-function ExperimentsTable({ experiments, selectedId, onSelect }: {
-  experiments: ExperimentSummary[]; selectedId: number | null; onSelect: (id: number | null) => void;
+function ExperimentsTable({ experiments, selectedId, onSelect, onChanged }: {
+  experiments: ExperimentSummary[]; selectedId: number | null; onSelect: (id: number | null) => void; onChanged: () => void;
 }) {
   if (experiments.length === 0) {
     return <div style={{ ...mono, color: "var(--text-muted)", padding: "1rem" }}>No experiments yet.</div>;
@@ -440,7 +501,7 @@ function ExperimentsTable({ experiments, selectedId, onSelect }: {
               </div>
               <div style={{ color: "var(--text-secondary)" }}>{e.gatheringHours ? `${e.gatheringHours.toFixed(0)}h` : "—"}</div>
             </div>
-            {expanded && <ExperimentDetailPanel id={e.id} />}
+            {expanded && <ExperimentDetailPanel id={e.id} status={e.status} onChanged={onChanged} />}
           </div>
         );
       })}
@@ -453,7 +514,7 @@ function ExperimentsTable({ experiments, selectedId, onSelect }: {
 export default function ExperimentsOverview({ enabled }: { enabled: boolean }) {
   const [view, setView] = useState<"experiments" | "settings">("experiments");
   const [selectedId, setSelectedId] = useState<number | null>(null);
-  const { experiments, pipeline, isLoading, hasLoaded, error } = useExperiments(enabled);
+  const { experiments, pipeline, isLoading, hasLoaded, error, refresh } = useExperiments(enabled);
   const settings = useExperimentSettings(enabled);
 
   // Surface a banner when the core automation workers are paused.
@@ -496,7 +557,7 @@ export default function ExperimentsOverview({ enabled }: { enabled: boolean }) {
           {isLoading && !hasLoaded ? (
             <div style={{ ...mono, color: "var(--text-muted)", padding: "1rem" }}>Loading experiments…</div>
           ) : (
-            <ExperimentsTable experiments={experiments} selectedId={selectedId} onSelect={setSelectedId} />
+            <ExperimentsTable experiments={experiments} selectedId={selectedId} onSelect={setSelectedId} onChanged={refresh} />
           )}
         </>
       )}

--- a/src/components/ExperimentsOverview.tsx
+++ b/src/components/ExperimentsOverview.tsx
@@ -424,9 +424,15 @@ function ExperimentDetailPanel({ id, status, onChanged }: { id: number; status: 
   const startMs = detail.windowStart ? Date.parse(detail.windowStart) : 0;
   const endMs = detail.windowEnd ? Date.parse(detail.windowEnd) : 0;
 
+  // useExperimentDetail isn't re-fetched after an action, so detail.status can
+  // lag behind the row's status prop (which onChanged() refreshes). Treat the
+  // experiment as terminal as soon as EITHER source says so, so the action bar
+  // disappears immediately after a successful abort/retire.
+  const actionStatus = TERMINAL_STATUSES.has(status) ? status : (detail.status || status);
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "0.9rem", padding: "0.75rem 0.25rem" }}>
-      <ExperimentActions id={id} status={detail.status || status} onChanged={onChanged} />
+      <ExperimentActions id={id} status={actionStatus} onChanged={onChanged} />
       {detail.statsError && (
         <div style={{ ...mono, fontSize: "0.62rem", color: "#e0a060", background: "#f0a03012", border: "1px solid #f0a03030", borderRadius: "var(--radius-sm)", padding: "0.5rem 0.7rem" }}>
           {detail.statsError}

--- a/src/hooks/useExperiments.ts
+++ b/src/hooks/useExperiments.ts
@@ -20,12 +20,26 @@ export function useExperiments(enabled: boolean) {
   const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // refresh re-fetches the list on demand (e.g. right after an abort/retire), so
+  // the operator doesn't wait out the 30s poll to see the new terminal status.
+  const refresh = useCallback(async () => {
+    try {
+      const data = await fetchExperiments();
+      setExperiments(data.experiments ?? []);
+      setPipeline(data.pipeline ?? null);
+      setError(null);
+      setHasLoaded(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load experiments");
+    }
+  }, []);
+
   useEffect(() => {
     if (!enabled || !isAuthenticated) return;
     let cancelled = false;
     let isFirst = true;
 
-    const refresh = async () => {
+    const tick = async () => {
       if (isFirst) setIsLoading(true);
       try {
         const data = await fetchExperiments();
@@ -42,12 +56,12 @@ export function useExperiments(enabled: boolean) {
       }
     };
 
-    refresh();
-    const interval = setInterval(refresh, 30000);
+    tick();
+    const interval = setInterval(tick, 30000);
     return () => { cancelled = true; clearInterval(interval); };
   }, [enabled, isAuthenticated]);
 
-  return { experiments, pipeline, isLoading, hasLoaded, error };
+  return { experiments, pipeline, isLoading, hasLoaded, error, refresh };
 }
 
 // useExperimentDetail fetches one experiment's full stats on demand (when a row is

--- a/src/hooks/useExperiments.ts
+++ b/src/hooks/useExperiments.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   fetchExperiments,
   fetchExperimentDetail,
@@ -20,19 +20,33 @@ export function useExperiments(enabled: boolean) {
   const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // refresh re-fetches the list on demand (e.g. right after an abort/retire), so
-  // the operator doesn't wait out the 30s poll to see the new terminal status.
-  const refresh = useCallback(async () => {
+  // Monotonic request id: the poll and an on-demand refresh both write the same
+  // state, so without ordering a slow poll could land after a newer refresh and
+  // flip the UI back to the pre-action status. Only the latest request applies.
+  const reqSeq = useRef(0);
+
+  const load = useCallback(async () => {
+    const seq = ++reqSeq.current;
     try {
       const data = await fetchExperiments();
+      if (seq !== reqSeq.current) return; // superseded by a newer request
       setExperiments(data.experiments ?? []);
       setPipeline(data.pipeline ?? null);
       setError(null);
       setHasLoaded(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load experiments");
+      if (seq === reqSeq.current) setError(err instanceof Error ? err.message : "Failed to load experiments");
     }
   }, []);
+
+  // refresh re-fetches the list on demand (e.g. right after an abort/retire), so
+  // the operator doesn't wait out the 30s poll to see the new terminal status.
+  // Guarded on enabled/auth like the poll so it's a no-op for an inactive or
+  // logged-out tab.
+  const refresh = useCallback(async () => {
+    if (!enabled || !isAuthenticated) return;
+    await load();
+  }, [enabled, isAuthenticated, load]);
 
   useEffect(() => {
     if (!enabled || !isAuthenticated) return;
@@ -41,25 +55,15 @@ export function useExperiments(enabled: boolean) {
 
     const tick = async () => {
       if (isFirst) setIsLoading(true);
-      try {
-        const data = await fetchExperiments();
-        if (cancelled) return;
-        setExperiments(data.experiments ?? []);
-        setPipeline(data.pipeline ?? null);
-        setError(null);
-        setHasLoaded(true);
-      } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load experiments");
-      } finally {
-        if (!cancelled && isFirst) setIsLoading(false);
-        isFirst = false;
-      }
+      await load();
+      if (!cancelled && isFirst) setIsLoading(false);
+      isFirst = false;
     };
 
     tick();
     const interval = setInterval(tick, 30000);
     return () => { cancelled = true; clearInterval(interval); };
-  }, [enabled, isAuthenticated]);
+  }, [enabled, isAuthenticated, load]);
 
   return { experiments, pipeline, isLoading, hasLoaded, error, refresh };
 }


### PR DESCRIPTION
## What

Per-experiment **Abort** and **Retire** operator actions on the Bandit Experiments tab — the UI half of the operator terminate path. Backed by the new `POST /dashboard/experiments/{abort,retire}` endpoints in getlantern/lantern-cloud#2912.

Until now the experiments dashboard was read-only (plus the settings knobs); there was no way to terminate a stuck/unwanted experiment without the `lc` CLI. This adds buttons in the expanded experiment detail panel.

## Details

- **`client.ts`**: `abortExperiment(id, reason)` / `retireExperiment(id, reason)` — POST with the same 401 refresh-retry pattern as `updateExperimentSetting`; return the updated `ExperimentSummary`.
- **`useExperiments`**: expose a manual `refresh()` so the list reflects the new terminal status immediately rather than waiting out the 30s poll.
- **`ExperimentsOverview`**: an "Operator actions" bar in the detail panel with Abort (red) / Retire (amber) buttons. Prompts for an optional reason (Cancel backs out), shows success/error inline, and is **hidden once the experiment is terminal** (`promoted`/`retired`/`aborted`).

Both verbs drive the identical server-side teardown the `lc experiments` CLI uses: disable challenger track, zero VPS pool, deprecate routes, record decision, set terminal status.

## Dependency

Requires getlantern/lantern-cloud#2912 (the `/dashboard/experiments/{abort,retire}` handlers) deployed to the target API environment.

## Testing

`tsc -b` clean; eslint clean on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Abort” and “Retire” actions to each experiment’s expanded detail panel.
  * Operators can confirm the action and optionally enter a reason.
  * The experiments list refreshes after a successful action, and the action controls hide immediately for terminal states.
* **Bug Fixes**
  * Improved handling of expired sign-in sessions by retrying once after re-authentication.
  * Action failures now report clearer error details, including the server response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->