### PR TITLE
experiments: show target market instead of datacenter region (eng#3651)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -616,8 +616,9 @@ export function getStreamURL(): string {
 export interface ExperimentSummary {
   id: number;
   status: string;
-  regionId: number;
-  regionName: string;
+  // ISO-3166 alpha-2 client market the experiment serves (its identity).
+  targetCountry: string;
+  // The out-of-country serving datacenter the challenger is pinned to.
   locationName: string;
   providerName: string;
   protocolName: string;

--- a/src/components/ExperimentsOverview.tsx
+++ b/src/components/ExperimentsOverview.tsx
@@ -475,7 +475,7 @@ function ExperimentsTable({ experiments, selectedId, onSelect, onChanged }: {
     <div style={card}>
       <div style={sectionLabel}>Experiments</div>
       <div style={headerStyle}>
-        <div>ID</div><div>Status</div><div>Region / Location</div><div>Challenger → Control</div><div>Protocol</div><div>Decision</div><div>Gathering</div>
+        <div>ID</div><div>Status</div><div>Market / Serving DC</div><div>Challenger → Control</div><div>Protocol</div><div>Decision</div><div>Gathering</div>
       </div>
       {experiments.map((e) => {
         const expanded = selectedId === e.id;
@@ -493,7 +493,7 @@ function ExperimentsTable({ experiments, selectedId, onSelect, onChanged }: {
               <div style={{ color: "var(--text-muted)" }}>#{e.id}</div>
               <div><StatusBadge status={e.status} /></div>
               <div style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                <span style={{ color: "var(--text-primary)" }}>{e.regionName || `r${e.regionId}`}</span>
+                <span style={{ color: "var(--text-primary)" }}>{e.targetCountry || "—"}</span>
                 <span style={{ color: "var(--text-muted)" }}> / {e.locationName || "—"}{e.providerName ? ` (${e.providerName})` : ""}</span>
               </div>
               <div style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>


### PR DESCRIPTION
Consumer side of the bandit experiment market pivot (getlantern/engineering#3651). Pairs with getlantern/lantern-cloud#2916, which changes the `ExperimentSummary` gRPC contract `region_id` → `target_country`.

## Changes
- `src/api/client.ts` — `ExperimentSummary`: `regionId: number` / `regionName: string` → `targetCountry: string` (the ISO-3166 alpha-2 client market the experiment serves; the serving DC remains in `locationName`).
- `src/components/ExperimentsOverview.tsx` — table header "Region / Location" → "Market / Serving DC"; render `e.targetCountry` instead of `regionName`/`r{regionId}`. Per-country charts were already aligned.

## Note
Ship together with lantern-cloud#2916 — this consumes the new field name. Could not run `tsc` locally (node_modules not installed); the change is minimal and type-consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated experiment details to show a market/serving data center label instead of region/location.
  * Experiment summaries now include the target country for each experiment.

* **Bug Fixes**
  * Simplified experiment table rows to display the most relevant geographic information consistently when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->